### PR TITLE
Copied multierror from terraform/helper/multierror into HCL tree

### DIFF
--- a/hcl/parse.go
+++ b/hcl/parse.go
@@ -2,8 +2,7 @@ package hcl
 
 import (
 	"sync"
-
-	"github.com/hashicorp/terraform/helper/multierror"
+	"github.com/hashicorp/hcl/helper/multierror"
 )
 
 // hclErrors are the errors built up from parsing. These should not

--- a/helper/multierror/error.go
+++ b/helper/multierror/error.go
@@ -1,0 +1,54 @@
+package multierror
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Error is an error type to track multiple errors. This is used to
+// accumulate errors in cases such as configuration parsing, and returning
+// them as a single error.
+type Error struct {
+	Errors []error
+}
+
+func (e *Error) Error() string {
+	points := make([]string, len(e.Errors))
+	for i, err := range e.Errors {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	return fmt.Sprintf(
+		"%d error(s) occurred:\n\n%s",
+		len(e.Errors), strings.Join(points, "\n"))
+}
+
+func (e *Error) GoString() string {
+	return fmt.Sprintf("*%#v", *e)
+}
+
+// ErrorAppend is a helper function that will append more errors
+// onto an Error in order to create a larger multi-error. If the
+// original error is not an Error, it will be turned into one.
+func ErrorAppend(err error, errs ...error) *Error {
+	if err == nil {
+		err = new(Error)
+	}
+
+	switch err := err.(type) {
+	case *Error:
+		if err == nil {
+			err = new(Error)
+		}
+
+		err.Errors = append(err.Errors, errs...)
+		return err
+	default:
+		newErrs := make([]error, len(errs)+1)
+		newErrs[0] = err
+		copy(newErrs[1:], errs)
+		return &Error{
+			Errors: newErrs,
+		}
+	}
+}

--- a/helper/multierror/error_test.go
+++ b/helper/multierror/error_test.go
@@ -1,0 +1,56 @@
+package multierror
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestError_Impl(t *testing.T) {
+	var raw interface{}
+	raw = &Error{}
+	if _, ok := raw.(error); !ok {
+		t.Fatal("Error must implement error")
+	}
+}
+
+func TestErrorError(t *testing.T) {
+	expected := `2 error(s) occurred:
+
+* foo
+* bar`
+
+	errors := []error{
+		errors.New("foo"),
+		errors.New("bar"),
+	}
+
+	multi := &Error{errors}
+	if multi.Error() != expected {
+		t.Fatalf("bad: %s", multi.Error())
+	}
+}
+
+func TestErrorAppend_Error(t *testing.T) {
+	original := &Error{
+		Errors: []error{errors.New("foo")},
+	}
+
+	result := ErrorAppend(original, errors.New("bar"))
+	if len(result.Errors) != 2 {
+		t.Fatalf("wrong len: %d", len(result.Errors))
+	}
+
+	original = &Error{}
+	result = ErrorAppend(original, errors.New("bar"))
+	if len(result.Errors) != 1 {
+		t.Fatalf("wrong len: %d", len(result.Errors))
+	}
+}
+
+func TestErrorAppend_NonError(t *testing.T) {
+	original := errors.New("foo")
+	result := ErrorAppend(original, errors.New("bar"))
+	if len(result.Errors) != 2 {
+		t.Fatalf("wrong len: %d", len(result.Errors))
+	}
+}

--- a/json/parse.go
+++ b/json/parse.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl/hcl"
-	"github.com/hashicorp/terraform/helper/multierror"
+	"github.com/hashicorp/hcl/helper/multierror"
 )
 
 // jsonErrors are the errors built up from parsing. These should not


### PR DESCRIPTION
Removes dependency on Terraform source. Felt this was fine as the multierror code is so small, it didn't seem worth it to create a new project that both Terraform and HCL depend on.
