### PR TITLE
add PoC cmd converting HCL to JSON

### DIFF
--- a/cmd/hcl2json/main.go
+++ b/cmd/hcl2json/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/hashicorp/hcl"
+)
+
+func main() {
+	d, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("err: %s", err)
+	}
+
+	var obj interface{}
+	err = hcl.Decode(&obj, string(d))
+	if err != nil {
+		log.Fatalf("err: %s", err)
+	}
+
+	out, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		log.Fatalf("err: %s", err)
+	}
+
+	fmt.Println(string(out))
+}

--- a/cmd/hcl2json/main.go
+++ b/cmd/hcl2json/main.go
@@ -11,7 +11,25 @@ import (
 )
 
 func main() {
-	d, err := ioutil.ReadAll(os.Stdin)
+	args := os.Args
+
+	if 2 != len(args) {
+		usage()
+	}
+
+	file := args[1]
+
+	var d []byte
+	var err error
+
+	if "-h" == file {
+		usage()
+	} else if "-" == file {
+		d, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		d, err = ioutil.ReadFile(file)
+	}
+
 	if err != nil {
 		log.Fatalf("err: %s", err)
 	}
@@ -28,4 +46,9 @@ func main() {
 	}
 
 	fmt.Println(string(out))
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: hcl2json <file>")
+	os.Exit(1)
 }

--- a/cmd/hcl2json/main.go
+++ b/cmd/hcl2json/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -22,14 +23,14 @@ func main() {
 
 type CLI struct {
 	Args   []string
-	Stdin  *os.File
-	Stdout *os.File
-	Stderr *os.File
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
 }
 
 func (c *CLI) Run() int {
 	if 2 != len(c.Args) {
-		c.Usage()
+		return c.Usage()
 	}
 
 	file := c.Args[1]

--- a/cmd/hcl2json/main_test.go
+++ b/cmd/hcl2json/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestCLINoParamsPrintsUsage(t *testing.T) {
+	fakeReader := strings.NewReader("")
+	fakeOut := new(bytes.Buffer)
+	fakeErr := new(bytes.Buffer)
+
+	cli := &CLI{
+		Args:   []string{"hcl2json"},
+		Stdin:  fakeReader,
+		Stdout: fakeOut,
+		Stderr: fakeErr,
+	}
+
+	cli.Run()
+
+	actual := fakeErr.String()
+	expected := "usage: hcl2json <file>\n"
+
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
+	outStr := fakeOut.String()
+	if outStr != "" {
+		t.Fatalf("err:\n%s", outStr)
+	}
+}
+
+func TestCLIDashHPrintsUsage(t *testing.T) {
+	fakeReader := strings.NewReader("")
+	fakeOut := new(bytes.Buffer)
+	fakeErr := new(bytes.Buffer)
+
+	cli := &CLI{
+		Args:   []string{"hcl2json", "-h"},
+		Stdin:  fakeReader,
+		Stdout: fakeOut,
+		Stderr: fakeErr,
+	}
+
+	cli.Run()
+
+	actual := fakeErr.String()
+	expected := "usage: hcl2json <file>\n"
+
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+
+	outStr := fakeOut.String()
+	if outStr != "" {
+		t.Fatalf("err:\n%s", outStr)
+	}
+}
+
+func TestCLIFilenameReadsFile(t *testing.T) {
+	fakeReader := strings.NewReader("")
+	fakeOut := new(bytes.Buffer)
+	fakeErr := new(bytes.Buffer)
+
+	fakeFile, _ := ioutil.TempFile("", "hcl2json")
+
+	cli := &CLI{
+		Args:   []string{"hcl2json", fakeFile.Name()},
+		Stdin:  fakeReader,
+		Stdout: fakeOut,
+		Stderr: fakeErr,
+	}
+
+	cli.Run()
+
+	errStr := fakeErr.String()
+	if errStr != "" {
+		t.Fatalf("err:\n%s", errStr)
+	}
+
+	actual := fakeOut.String()
+	expected := "{}\n"
+	if actual != expected {
+		t.Fatalf("out:\n%s", actual)
+	}
+}
+
+func TestCLIDashReadsFile(t *testing.T) {
+	fakeReader := strings.NewReader("\"key\"=\"val\"\n")
+	fakeOut := new(bytes.Buffer)
+	fakeErr := new(bytes.Buffer)
+
+	cli := &CLI{
+		Args:   []string{"hcl2json", "-"},
+		Stdin:  fakeReader,
+		Stdout: fakeOut,
+		Stderr: fakeErr,
+	}
+
+	cli.Run()
+
+	errStr := fakeErr.String()
+	if errStr != "" {
+		t.Fatalf("err:\n%s", errStr)
+	}
+
+	actual := fakeOut.String()
+	expected := "{\n  \"key\": \"val\"\n}\n"
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}


### PR DESCRIPTION
This adds an `hcl2json` command which reads HCL from STDIN and writes indented JSON to STDOUT.

At the moment it is not friendly at all, and probably is only useful for people who are testing HCL code changes. Before merging, it should be a friendly tool to allow people who :heart: HCL to use it in environments where importing this package is unwieldy.

Some things it should probably do:
- [x] `hcl2json`, `hcl2json -h` should print usage
- [x] `hcl2json foo.hcl` should read from `foo.hcl`
- [x] `hcl2json -` should read from STDIN
- [x] refactor to extract a CLI struct for testing
- [x] add tests for the above functionality
- build through gox?

Fixes https://github.com/hashicorp/hcl/issues/32