### PR TITLE
Added hcl to json example for nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ variable "ami" {
     description = "the AMI to use"
 }
 ```
+This would be equivalent to the following json:
+``` json
+{
+  "variable": {
+      "ami": {
+          "description": "the AMI to use"
+        }
+    }
+}
+```
 
 ## Thanks
 


### PR DESCRIPTION
It was unclear how nested object example in hcl would map to json. Readme now updated to include an example of the json equivalent to a hcl nested object