### PR TITLE
Decode into non-nil pointer's existing value.

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -257,6 +257,11 @@ func (d *decoder) decodeMap(name string, o *hcl.Object, result reflect.Value) er
 }
 
 func (d *decoder) decodePtr(name string, o *hcl.Object, result reflect.Value) error {
+	// if pointer is not nil, decode into existing value
+	if !result.IsNil() {
+		return d.decode(name, o, result.Elem())
+	}
+
 	// Create an element of the concrete (non pointer) type and decode
 	// into that. Then set the value of the pointer to this type.
 	resultType := result.Type()

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -350,6 +350,35 @@ func TestDecode_structurePtr(t *testing.T) {
 	}
 }
 
+func TestDecode_nonNilStructurePtr(t *testing.T) {
+	type V struct {
+		Key        int
+		Foo        string
+		DontChange string
+	}
+
+	actual := &V{
+		Key:        42,
+		Foo:        "foo",
+		DontChange: "don't change me",
+	}
+
+	err := Decode(&actual, testReadFile(t, "flat.hcl"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &V{
+		Key:        7,
+		Foo:        "bar",
+		DontChange: "don't change me",
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Actual: %#v\n\nExpected: %#v", actual, expected)
+	}
+}
+
 func TestDecode_structureArray(t *testing.T) {
 	// This test is extracted from a failure in Consul (consul.io),
 	// hence the interesting structure naming.


### PR DESCRIPTION
If decoding into a pointer, and the pointer points to a value, decode
into the exitsing value.  Otherwise, decode into a new value and point
to it.

Addresses issue #38.
