### PR TITLE
hcl/parser: store position on every parse err [GH-54]

### DIFF
--- a/hcl/parser/error.go
+++ b/hcl/parser/error.go
@@ -1,0 +1,17 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/hcl/token"
+)
+
+// PosError is a parse error that contains a position.
+type PosError struct {
+	Pos token.Pos
+	Err error
+}
+
+func (e *PosError) Error() string {
+	return fmt.Sprintf("At %s: %s", e.Pos, e.Err)
+}

--- a/hcl/parser/error_test.go
+++ b/hcl/parser/error_test.go
@@ -1,0 +1,9 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestPosError_impl(t *testing.T) {
+	var _ error = new(PosError)
+}


### PR DESCRIPTION
Fixes #54 

This introduces a special error struct so that the position is available on every parse error.