### PR TITLE
Adding Godoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HCL
 
+[![GoDoc](https://godoc.org/github.com/hashicorp/hcl?status.png)](https://godoc.org/github.com/hashicorp/hcl)
+
 HCL (HashiCorp Configuration Language) is a configuration language built
 by HashiCorp. The goal of HCL is to build a structured configuration language
 that is both human and machine friendly for use with command-line tools, but


### PR DESCRIPTION
Makes understanding the consumable API much simpler rather than digging through source code.