### PR TITLE
Handle multiple interpolations in string.

### DIFF
--- a/hcl/strconv/quote.go
+++ b/hcl/strconv/quote.go
@@ -86,7 +86,12 @@ func Unquote(s string) (t string, err error) {
 				return "", ErrSyntax
 			}
 			if len(s) == 0 {
+				// If there's no string left, we're done!
 				break
+			} else {
+				// If there's more left, we need to pop back up to the top of the loop
+				// in case there's another interpolation in this string.
+				continue
 			}
 		}
 

--- a/hcl/strconv/quote_test.go
+++ b/hcl/strconv/quote_test.go
@@ -37,6 +37,8 @@ var unquotetests = []unQuoteTest{
 	{`"'"`, "'"},
 	{`"${file("foo")}"`, `${file("foo")}`},
 	{`"${file(\"foo\")}"`, `${file("foo")}`},
+	{`"echo ${var.region}${element(split(",",var.zones),0)}"`,
+		`echo ${var.region}${element(split(",",var.zones),0)}`},
 }
 
 var misquoted = []string{


### PR DESCRIPTION
A user testing an RC release of Terraform 0.6.7 found the following
string unexpectedly caused a syntax error:

    "echo ${var.region}${element(split(",",var.zones),0)}"

This fixes the error and covers it with a test.