### PR TITLE
Fix scanning of identifiers of the form 'map.key'

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -44,6 +44,15 @@ func TestDecode_interface(t *testing.T) {
 			},
 		},
 		{
+			"tfvars.hcl",
+			false,
+			map[string]interface{}{
+				"regularvar": "Should work",
+				"map.key1":   "Value",
+				"map.key2":   "Other value",
+			},
+		},
+		{
 			"escape.hcl",
 			false,
 			map[string]interface{}{

--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -516,7 +516,7 @@ func (s *Scanner) scanDigits(ch rune, base, n int) rune {
 func (s *Scanner) scanIdentifier() string {
 	offs := s.srcPos.Offset - s.lastCharLen
 	ch := s.next()
-	for isLetter(ch) || isDigit(ch) || ch == '-' {
+	for isLetter(ch) || isDigit(ch) || ch == '-' || ch == '.' {
 		ch = s.next()
 	}
 

--- a/test-fixtures/tfvars.hcl
+++ b/test-fixtures/tfvars.hcl
@@ -1,0 +1,3 @@
+regularvar = "Should work"
+map.key1 = "Value"
+map.key2 = "Other value"


### PR DESCRIPTION
This is used in `.tfvars` files for Terraform in order to allow overriding values in maps, for example:

```hcl
    map.key1 = "Value"
    map.key2 = "OtherValue"
```

Not sure this is quite enough to fix the issues reported in 0.6.7 of Terraform, but it moves us past the parsing error.

