### PR TITLE
Support HEREDOCs in lists

### DIFF
--- a/hcl/parser/parser.go
+++ b/hcl/parser/parser.go
@@ -264,7 +264,7 @@ func (p *Parser) listType() (*ast.ListType, error) {
 	for {
 		tok := p.scan()
 		switch tok.Type {
-		case token.NUMBER, token.FLOAT, token.STRING:
+		case token.NUMBER, token.FLOAT, token.STRING, token.HEREDOC:
 			if needComma {
 				return nil, &PosError{
 					Pos: tok.Pos,

--- a/hcl/parser/parser_test.go
+++ b/hcl/parser/parser_test.go
@@ -64,6 +64,15 @@ func TestListType(t *testing.T) {
 			`foo = ["123", 123]`,
 			[]token.Type{token.STRING, token.NUMBER},
 		},
+		{
+			`foo = [1,
+"string",
+<<EOF
+heredoc contents
+EOF
+]`,
+			[]token.Type{token.NUMBER, token.STRING, token.HEREDOC},
+		},
 	}
 
 	for _, l := range literals {


### PR DESCRIPTION
This fixes a regression in Terraform where HEREDOCS were previously supported in lists, reported in hashicorp/terraform#4065.