### PR TITLE
Fix scanner for Windows line endings and add tests

### DIFF
--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -399,6 +399,13 @@ func (s *Scanner) scanHeredoc() {
 		return
 	}
 
+	// Ignore the '\r' in Windows line endings
+	if ch == '\r' {
+		if s.peek() == '\n' {
+			ch = s.next()
+		}
+	}
+
 	// If we didn't reach a newline then that is also not good
 	if ch != '\n' {
 		s.err("invalid characters in heredoc anchor")


### PR DESCRIPTION
I think this should be enough to fix hashicorp/terraform#4069, though this is not yet verified and changes to the parser may also be necessary.