### PR TITLE
Add support for indented HEREDOC terminators

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -92,6 +92,11 @@ func TestDecode_interface(t *testing.T) {
 			map[string]interface{}{"foo": testhelper.Unix2dos("bar\nbaz\n")},
 		},
 		{
+			"multiline_indented.hcl",
+			false,
+			map[string]interface{}{"foo": "        bar\n        baz\n"},
+		},
+		{
 			"multiline_no_eof.hcl",
 			false,
 			map[string]interface{}{"foo": testhelper.Unix2dos("bar\nbaz\n"), "key": "value"},

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -94,7 +94,12 @@ func TestDecode_interface(t *testing.T) {
 		{
 			"multiline_indented.hcl",
 			false,
-			map[string]interface{}{"foo": "        bar\n        baz\n"},
+			map[string]interface{}{"foo": "  bar\n  baz\n"},
+		},
+		{
+			"multiline_no_hanging_indent.hcl",
+			false,
+			map[string]interface{}{"foo": "  baz\n    bar\n      foo\n"},
 		},
 		{
 			"multiline_no_eof.hcl",

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -94,12 +94,12 @@ func TestDecode_interface(t *testing.T) {
 		{
 			"multiline_indented.hcl",
 			false,
-			map[string]interface{}{"foo": "  bar\n  baz\n"},
+			map[string]interface{}{"foo": testhelper.Unix2dos("  bar\n  baz\n")},
 		},
 		{
 			"multiline_no_hanging_indent.hcl",
 			false,
-			map[string]interface{}{"foo": "  baz\n    bar\n      foo\n"},
+			map[string]interface{}{"foo": testhelper.Unix2dos("  baz\n    bar\n      foo\n")},
 		},
 		{
 			"multiline_no_eof.hcl",

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/token"
 	"strings"
+
+	"github.com/hashicorp/hcl/hcl/token"
 )
 
 var f100 = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
@@ -377,6 +378,14 @@ func TestRealExample(t *testing.T) {
 Main interface
 EOF
 	    }
+	    
+		network_interface {
+	        device_index = 1
+	        description = <<-EOF
+			Outer text
+				Indented text
+			EOF
+		}
 	}`
 
 	literals := []struct {
@@ -435,6 +444,15 @@ EOF
 		{token.ASSIGN, `=`},
 		{token.HEREDOC, "<<EOF\nMain interface\nEOF\n"},
 		{token.RBRACE, `}`},
+		{token.IDENT, `network_interface`},
+		{token.LBRACE, `{`},
+		{token.IDENT, `device_index`},
+		{token.ASSIGN, `=`},
+		{token.NUMBER, `1`},
+		{token.IDENT, `description`},
+		{token.ASSIGN, `=`},
+		{token.HEREDOC, "<<-EOF\n\t\t\tOuter text\n\t\t\t\tIndented text\n\t\t\tEOF\n"},
+		{token.RBRACE, `}`},
 		{token.RBRACE, `}`},
 		{token.EOF, ``},
 	}
@@ -447,7 +465,7 @@ EOF
 		}
 
 		if l.literal != tok.Text {
-			t.Errorf("got: %s want %s\n", tok, l.literal)
+			t.Errorf("got:\n%+v\n%s\n want:\n%+v\n%s\n", []byte(tok.String()), tok, []byte(l.literal), l.literal)
 		}
 	}
 

--- a/hcl/token/token.go
+++ b/hcl/token/token.go
@@ -148,7 +148,8 @@ func (t Token) Value() interface{} {
 			panic("heredoc doesn't contain newline")
 		}
 
-		return string(t.Text[idx+1 : len(t.Text)-idx+1])
+		// Trim any trailing whitespace from the start of the marker
+		return strings.TrimRight(string(t.Text[idx+1:len(t.Text)-idx+1]), " \t")
 	case STRING:
 		// Determine the Unquote method to use. If it came from JSON,
 		// then we need to use the built-in unquote since we have to

--- a/hcl/token/token.go
+++ b/hcl/token/token.go
@@ -142,14 +142,7 @@ func (t Token) Value() interface{} {
 	case IDENT:
 		return t.Text
 	case HEREDOC:
-		// We need to find the end of the marker
-		idx := strings.IndexByte(t.Text, '\n')
-		if idx == -1 {
-			panic("heredoc doesn't contain newline")
-		}
-
-		// Trim any trailing whitespace from the start of the marker
-		return strings.TrimRight(string(t.Text[idx+1:len(t.Text)-idx+1]), " \t")
+		return unindentHeredoc(t.Text)
 	case STRING:
 		// Determine the Unquote method to use. If it came from JSON,
 		// then we need to use the built-in unquote since we have to
@@ -168,4 +161,54 @@ func (t Token) Value() interface{} {
 	default:
 		panic(fmt.Sprintf("unimplemented Value for type: %s", t.Type))
 	}
+}
+
+// unindentHeredoc returns the string content of a HEREDOC if it is started with <<
+// and the content of a HEREDOC with the hanging indent removed if it is started with
+// a <<-, and the terminating line is at least as indented as the least indented line.
+func unindentHeredoc(heredoc string) string {
+	// We need to find the end of the marker
+	idx := strings.IndexByte(heredoc, '\n')
+	if idx == -1 {
+		panic("heredoc doesn't contain newline")
+	}
+
+	unindent := heredoc[2] == '-'
+
+	// We can optimize if the heredoc isn't marked for indentation
+	if !unindent {
+		return string(heredoc[idx+1 : len(heredoc)-idx+1])
+	}
+
+	// We need to unindent each line based on the indentation level of the marker
+	lines := strings.Split(string(heredoc[idx+1:len(heredoc)-idx+2]), "\n")
+	whitespacePrefix := lines[len(lines)-1]
+
+	isIndented := true
+	for _, v := range lines {
+		if strings.HasPrefix(v, whitespacePrefix) {
+			continue
+		}
+
+		isIndented = false
+		break
+	}
+
+	// If all lines are not at least as indented as the terminating mark, return the
+	// heredoc as is, but trim the leading space from the marker on the final line.
+	if !isIndented {
+		return strings.TrimRight(string(heredoc[idx+1:len(heredoc)-idx+1]), " \t")
+	}
+
+	unindentedLines := make([]string, len(lines))
+	for k, v := range lines {
+		if k == len(lines)-1 {
+			unindentedLines[k] = ""
+			break
+		}
+
+		unindentedLines[k] = strings.TrimPrefix(v, whitespacePrefix)
+	}
+
+	return strings.Join(unindentedLines, "\n")
 }

--- a/test-fixtures/multiline_indented.hcl
+++ b/test-fixtures/multiline_indented.hcl
@@ -1,4 +1,4 @@
 foo = <<-EOF
         bar
         baz
-    EOF
+      EOF

--- a/test-fixtures/multiline_indented.hcl
+++ b/test-fixtures/multiline_indented.hcl
@@ -1,0 +1,4 @@
+foo = <<-EOF
+        bar
+        baz
+    EOF

--- a/test-fixtures/multiline_no_hanging_indent.hcl
+++ b/test-fixtures/multiline_no_hanging_indent.hcl
@@ -1,0 +1,5 @@
+foo = <<-EOF
+  baz
+    bar
+      foo
+      EOF


### PR DESCRIPTION
This PR adds support for the style of HEREDOC often used in Ruby which allows the terminating marker to be indented if the HEREDOC is started with the sequence "<<-" rather than the usual "<<". This allows users to express documents with more natural indentation:

```
resource "template_file" "test" {
    template = <<-HEREDOC
        First Line
        Second Line
    HEREDOC
}
```

Note that this does not attempt to add any semantics around removing hanging indent from the actual text of the document, so extra indentation would still be present. We could make use of the canonical style for HCL herre to remove the hanging indent in the style of Ruby which would probably be more predictable for users.

Fixes https://github.com/hashicorp/hcl/issues/9

cc @phinze, @mitchellh