### PR TITLE
decoder: do nothing if a map item has no key

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -336,6 +336,9 @@ func (d *decoder) decodeMap(name string, node ast.Node, result reflect.Value) er
 		if item.Val == nil {
 			continue
 		}
+		if len(item.Keys) == 0 {
+			continue
+		}
 
 		// Get the key we're dealing with, which is the first item
 		keyStr := item.Keys[0].Token.Value().(string)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -273,6 +273,26 @@ func TestDecode_interface(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"subsection-panic.hcl",
+			false,
+			map[string]interface{}{
+				"section": []map[string]interface{}{
+					map[string]interface{}{
+						"subsection": []map[string]interface{}{
+							map[string]interface{}{},
+						},
+					},
+					map[string]interface{}{},
+					map[string]interface{}{
+						"subsection": []map[string]interface{}{
+							map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/test-fixtures/subsection-panic.hcl
+++ b/test-fixtures/subsection-panic.hcl
@@ -1,0 +1,6 @@
+section {
+          subsection {
+          }
+}
+section "subsection" {
+}


### PR DESCRIPTION
HCL will panic on the following example:

```hcl
section {
          subsection {
          }
}
section "subsection" {
}
```

Fixes #73

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>