### PR TITLE
printer: don't write a newline on empty objects

### DIFF
--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -29,6 +29,7 @@ var data = []entry{
 	{"comment.input", "comment.golden"},
 	{"comment_aligned.input", "comment_aligned.golden"},
 	{"comment_standalone.input", "comment_standalone.golden"},
+	{"empty_block.input", "empty_block.golden"},
 }
 
 func TestFiles(t *testing.T) {

--- a/hcl/printer/testdata/empty_block.golden
+++ b/hcl/printer/testdata/empty_block.golden
@@ -1,0 +1,13 @@
+variable "foo" {}
+
+variable "foo" {}
+
+variable "foo" {
+	# Standalone comment should be still here
+}
+
+foo {}
+
+foo {
+	bar = "mssola"
+}

--- a/hcl/printer/testdata/empty_block.input
+++ b/hcl/printer/testdata/empty_block.input
@@ -1,0 +1,14 @@
+variable "foo" {}
+variable "foo" {
+}
+
+variable "foo" {
+	# Standalone comment should be still here
+}
+
+foo {
+}
+
+foo {
+  bar = "mssola"
+}


### PR DESCRIPTION
This is to match the same criteria as in gofmt.

Fixes #94

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>