### PR TITLE
Fix scanner tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,16 @@
-os: Windows Server 2012 R2
-
-clone_folder: c:\gopath\src\hashicorp\hcl
-
+version: "build-{branch}-{build}"
+image: Visual Studio 2015
+clone_folder: c:\gopath\src\github.com\hashicorp\hcl
 environment:
   GOPATH: c:\gopath
-  GO15VENDOREXPERIMENT: 1
+init:
+  - git config --global core.autocrlf true
+install:
+- cmd: >-
+    echo %Path%
 
+    go version
+
+    go env
 build_script:
-  - go get
-  - go test
+- cmd: go test -v ./...

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/hcl/testhelper"
 )
 
 func TestDecode_interface(t *testing.T) {
@@ -88,12 +89,12 @@ func TestDecode_interface(t *testing.T) {
 		{
 			"multiline.hcl",
 			false,
-			map[string]interface{}{"foo": "bar\nbaz\n"},
+			map[string]interface{}{"foo": testhelper.Unix2dos("bar\nbaz\n")},
 		},
 		{
 			"multiline_no_eof.hcl",
 			false,
-			map[string]interface{}{"foo": "bar\nbaz\n", "key": "value"},
+			map[string]interface{}{"foo": testhelper.Unix2dos("bar\nbaz\n"), "key": "value"},
 		},
 		{
 			"multiline.json",

--- a/hcl/fmtcmd/fmtcmd_test.go
+++ b/hcl/fmtcmd/fmtcmd_test.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"syscall"
 	"testing"
+
+	"github.com/hashicorp/hcl/testhelper"
 )
 
 var fixtureExtensions = []string{"hcl"}
@@ -324,6 +326,8 @@ func TestRunDiff(t *testing.T) {
 		}
 	}
 
+	expectedOutString := testhelper.Unix2dos(expectedOut.String())
+
 	_, stdout := mockIO()
 	err = Run(
 		[]string{path},
@@ -337,8 +341,8 @@ func TestRunDiff(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
-	if !regexp.MustCompile(expectedOut.String()).Match(stdout.Bytes()) {
-		t.Errorf("stdout want match:\n%s\ngot:\n%q", expectedOut, stdout)
+	if !regexp.MustCompile(expectedOutString).Match(stdout.Bytes()) {
+		t.Errorf("stdout want match:\n%s\ngot:\n%q", expectedOutString, stdout)
 	}
 }
 

--- a/testhelper/unix2dos.go
+++ b/testhelper/unix2dos.go
@@ -1,0 +1,15 @@
+package testhelper
+
+import (
+	"runtime"
+	"strings"
+)
+
+// Converts the line endings when on Windows
+func Unix2dos(unix string) string {
+	if runtime.GOOS != "windows" {
+		return unix
+	}
+
+	return strings.Replace(unix, "\n", "\r\n", -1)
+}


### PR DESCRIPTION
This is necessary because of the effects of autocrlf on Windows.