### PR TITLE
Return an error if object keys are not strings

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -337,6 +337,14 @@ func (d *decoder) decodeMap(name string, node ast.Node, result reflect.Value) er
 			continue
 		}
 
+		// github.com/hashicorp/terraform/issue/5740
+		if len(item.Keys) == 0 {
+			return &parser.PosError{
+				Pos: node.Pos(),
+				Err: fmt.Errorf("%s: map must have string keys", name),
+			}
+		}
+
 		// Get the key we're dealing with, which is the first item
 		keyStr := item.Keys[0].Token.Value().(string)
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -246,6 +246,14 @@ func TestDecode_interface(t *testing.T) {
 		},
 
 		{
+			"nested_provider_bad.hcl",
+			true,
+			// This is not ideal but without significant rework of the decoder
+			// we get a partial result back as well as an error.
+			map[string]interface{}{},
+		},
+
+		{
 			"object_list.json",
 			false,
 			map[string]interface{}{

--- a/test-fixtures/nested_provider_bad.hcl
+++ b/test-fixtures/nested_provider_bad.hcl
@@ -1,0 +1,5 @@
+resource "aws" "web" {
+  provider = "aws" {
+    region = "us-west-2"
+  }
+}


### PR DESCRIPTION
This now gives an error instead of a panic when encountering configuration such as described in hashicorp/terraform#5740:

```
resource "aws" "web" {
  provider = "aws" {
    region = "us-west-2"
  }
}
```

We now return an error message - "hcl object keys must be a string" instead of crashing.

Fixes hashicorp/terraform#5740.