### PR TITLE
printer: output EOF newline in formatted hcl

### DIFF
--- a/hcl/printer/printer.go
+++ b/hcl/printer/printer.go
@@ -60,5 +60,8 @@ func Format(src []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	// Add trailing newline to result
+	buf.WriteString("\n")
+
 	return buf.Bytes(), nil
 }

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -1,4 +1,4 @@
-// +build -windows
+// +build !windows
 // TODO(jen20): These need fixing on Windows but printer is not used right now
 // and red CI is making it harder to process other bugs, so ignore until
 // we get around to fixing them.package printer
@@ -116,27 +116,17 @@ func diff(aname, bname string, a, b []byte) error {
 // src is syntactically correct, and returns the resulting src or an error
 // if any.
 func format(src []byte) ([]byte, error) {
-	// parse src
-	node, err := parser.Parse(src)
+	formatted, err := Format(src)
 	if err != nil {
-		return nil, fmt.Errorf("parse: %s\n%s", err, src)
-	}
-
-	var buf bytes.Buffer
-
-	cfg := &Config{}
-	if err := cfg.Fprint(&buf, node); err != nil {
-		return nil, fmt.Errorf("print: %s", err)
+		return nil, err
 	}
 
 	// make sure formatted output is syntactically correct
-	res := buf.Bytes()
-
-	if _, err := parser.Parse(src); err != nil {
+	if _, err := parser.Parse(formatted); err != nil {
 		return nil, fmt.Errorf("parse: %s\n%s", err, src)
 	}
 
-	return res, nil
+	return formatted, nil
 }
 
 // lineAt returns the line in text starting at offset offs.

--- a/hcl/printer/testdata/comment.golden
+++ b/hcl/printer/testdata/comment.golden
@@ -2,10 +2,10 @@
 
 // This comes from Terraform, as a test
 variable "foo" {
-	# Standalone comment should be still here
+  # Standalone comment should be still here
 
-	default     = "bar"
-	description = "bar" # yooo
+  default     = "bar"
+  description = "bar" # yooo
 }
 
 /* This is a multi line standalone
@@ -21,16 +21,16 @@ numbers = [1, 2] // another line here
 
 # Another comment
 variable = {
-	description = "bar" # another yooo
+  description = "bar" # another yooo
 
-	foo {
-		# Nested standalone
+  foo {
+    # Nested standalone
 
-		bar = "fatih"
-	}
+    bar = "fatih"
+  }
 }
 
 // lead comment
 foo {
-	bar = "fatih" // line comment 2 
+  bar = "fatih" // line comment 2 
 } // line comment 3

--- a/hcl/printer/testdata/comment_aligned.golden
+++ b/hcl/printer/testdata/comment_aligned.golden
@@ -1,32 +1,32 @@
 aligned {
-	# We have some aligned items below
-	foo     = "fatih"       # yoo1
-	default = "bar"         # yoo2
-	bar     = "bar and foo" # yoo3
+  # We have some aligned items below
+  foo     = "fatih"       # yoo1
+  default = "bar"         # yoo2
+  bar     = "bar and foo" # yoo3
 
-	default = {
-		bar = "example"
-	}
+  default = {
+    bar = "example"
+  }
 
-	#deneme arslan
-	fatih = ["fatih"] # yoo4
+  #deneme arslan
+  fatih = ["fatih"] # yoo4
 
-	#fatih arslan
-	fatiharslan = ["arslan"] // yoo5
+  #fatih arslan
+  fatiharslan = ["arslan"] // yoo5
 
-	default = {
-		bar = "example"
-	}
+  default = {
+    bar = "example"
+  }
 
-	security_groups = [
-		"foo",                                # kenya 1
-		"${aws_security_group.firewall.foo}", # kenya 2
-	]
+  security_groups = [
+    "foo",                                # kenya 1
+    "${aws_security_group.firewall.foo}", # kenya 2
+  ]
 
-	security_groups2 = [
-		"foo",                                # kenya 1
-		"bar",                                # kenya 1.5
-		"${aws_security_group.firewall.foo}", # kenya 2
-		"foobar",                             # kenya 3
-	]
+  security_groups2 = [
+    "foo",                                # kenya 1
+    "bar",                                # kenya 1.5
+    "${aws_security_group.firewall.foo}", # kenya 2
+    "foobar",                             # kenya 3
+  ]
 }

--- a/hcl/printer/testdata/comment_standalone.golden
+++ b/hcl/printer/testdata/comment_standalone.golden
@@ -1,12 +1,12 @@
 // A standalone comment 
 
 aligned {
-	# Standalone 1
+  # Standalone 1
 
-	a       = "bar" # yoo1
-	default = "bar" # yoo2
+  a       = "bar" # yoo1
+  default = "bar" # yoo2
 
-	# Standalone 2
+  # Standalone 2
 }
 
 # Standalone 3
@@ -14,3 +14,4 @@ aligned {
 numbers = [1, 2] // another line here
 
 # Standalone 4
+

--- a/hcl/printer/testdata/complexhcl.golden
+++ b/hcl/printer/testdata/complexhcl.golden
@@ -1,54 +1,54 @@
 variable "foo" {
-	default     = "bar"
-	description = "bar"
+  default     = "bar"
+  description = "bar"
 }
 
 developer = ["fatih", "arslan"]
 
 provider "aws" {
-	access_key = "foo"
-	secret_key = "bar"
+  access_key = "foo"
+  secret_key = "bar"
 }
 
 provider "do" {
-	api_key = "${var.foo}"
+  api_key = "${var.foo}"
 }
 
 resource "aws_security_group" "firewall" {
-	count = 5
+  count = 5
 }
 
 resource aws_instance "web" {
-	ami = "${var.foo}"
+  ami = "${var.foo}"
 
-	security_groups = [
-		"foo",
-		"${aws_security_group.firewall.foo}",
-	]
+  security_groups = [
+    "foo",
+    "${aws_security_group.firewall.foo}",
+  ]
 
-	network_interface {
-		device_index = 0
-		description  = "Main network interface"
-	}
+  network_interface {
+    device_index = 0
+    description  = "Main network interface"
+  }
 
-	network_interface = {
-		device_index = 1
+  network_interface = {
+    device_index = 1
 
-		description = <<EOF
+    description = <<EOF
 ANOTHER NETWORK INTERFACE
 EOF
-	}
+  }
 }
 
 resource "aws_instance" "db" {
-	security_groups = "${aws_security_group.firewall.*.id}"
-	VPC             = "foo"
+  security_groups = "${aws_security_group.firewall.*.id}"
+  VPC             = "foo"
 
-	depends_on = ["aws_instance.web"]
+  depends_on = ["aws_instance.web"]
 }
 
 output "web_ip" {
-	value = <<EOF
+  value = <<EOF
 TUBES
 EOF
 }

--- a/hcl/printer/testdata/empty_block.golden
+++ b/hcl/printer/testdata/empty_block.golden
@@ -3,11 +3,11 @@ variable "foo" {}
 variable "foo" {}
 
 variable "foo" {
-	# Standalone comment should be still here
+  # Standalone comment should be still here
 }
 
 foo {}
 
 foo {
-	bar = "mssola"
+  bar = "mssola"
 }

--- a/hcl/printer/testdata/list.golden
+++ b/hcl/printer/testdata/list.golden
@@ -3,17 +3,17 @@ foo = ["fatih", "arslan"]
 foo = ["bar", "qaz"]
 
 foo = ["zeynep",
-	"arslan",
+  "arslan",
 ]
 
 foo = ["fatih", "zeynep",
-	"arslan",
+  "arslan",
 ]
 
 foo = [
-	"vim-go",
-	"golang",
-	"hcl",
+  "vim-go",
+  "golang",
+  "hcl",
 ]
 
 foo = []
@@ -21,7 +21,7 @@ foo = []
 foo = [1, 2, 3, 4]
 
 foo = [
-	"kenya",
-	"ethiopia",
-	"columbia",
+  "kenya",
+  "ethiopia",
+  "columbia",
 ]


### PR DESCRIPTION
Noticed that the `hclfmt` tool (which uses hcl/printer) was chomping
the trailing newline from config files.

Here we switch to the more conventional newline-at-EOF output.

In the process of changing this, I realized that:

 * The printer_test.go build tag was wrong, so it wasn't running
 * The format() test helper was not exercising Format

So both of those fixes are included here