### PR TITLE
Allow printer to print single list file

### DIFF
--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -140,8 +140,31 @@ func (p *printer) output(n interface{}) []byte {
 			}
 
 			buf.Write(p.output(t.Items[index]))
+			// Write newlines for each ObjectItem in the list
+			// If the line isn't commented, and we aren't on the next to last line,
 			if !commented && index != len(t.Items)-1 {
-				buf.Write([]byte{newline, newline})
+				// Check if next item is valid
+				if ok := t.Items[index+1]; ok != nil {
+					// If next line is an assignment line,
+					// and the current line is an assignment line
+					// and the line doesn't contain a lead comment
+					if t.Items[index+1].Assign.IsValid() &&
+						t.Items[index].Assign.IsValid() &&
+						t.Items[index+1].LeadComment == nil {
+
+						switch t.Items[index].Val.(type) {
+						// Add two newlines for a list-type
+						case *ast.ListType:
+							buf.Write([]byte{newline, newline})
+							// Single newline for all other cases matching above
+						default:
+							buf.Write([]byte{newline})
+						}
+					} else {
+						// Two newlines by default
+						buf.Write([]byte{newline, newline})
+					}
+				}
 			}
 			index++
 		}

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -35,6 +35,7 @@ var data = []entry{
 	{"comment_aligned.input", "comment_aligned.golden"},
 	{"comment_standalone.input", "comment_standalone.golden"},
 	{"empty_block.input", "empty_block.golden"},
+	{"basic_list.input", "basic_list.golden"},
 }
 
 func TestFiles(t *testing.T) {

--- a/hcl/printer/testdata/basic_list.golden
+++ b/hcl/printer/testdata/basic_list.golden
@@ -1,0 +1,4 @@
+listed_var = "tested var"
+bacon = "delicious"
+number = 3
+bool_var = true

--- a/hcl/printer/testdata/basic_list.golden
+++ b/hcl/printer/testdata/basic_list.golden
@@ -2,3 +2,12 @@ listed_var = "tested var"
 bacon = "delicious"
 number = 3
 bool_var = true
+
+# another
+baz = "qux"
+
+block {}
+
+block2 {}
+
+foo = "again"

--- a/hcl/printer/testdata/basic_list.input
+++ b/hcl/printer/testdata/basic_list.input
@@ -1,0 +1,4 @@
+listed_var = "tested var"
+bacon = "delicious"
+number = 3
+bool_var = true

--- a/hcl/printer/testdata/basic_list.input
+++ b/hcl/printer/testdata/basic_list.input
@@ -2,3 +2,12 @@ listed_var = "tested var"
 bacon = "delicious"
 number = 3
 bool_var = true
+
+# another
+baz = "qux"
+
+block {}
+
+block2 {}
+
+foo = "again"


### PR DESCRIPTION
Currently the HCL Printer will print a file that contains a single
ast.ObjectList with two newlines after every ast.ObjectItem.

```
config-value = "value"

use = "theForce"

donut = true
```

This allows for the single list of ast.ObjectItem's to be printed with
only a single new line.

```
config-value = "value"
use = "theForce"
donut = true
```

ast.ObjectItem's which contain a ListType will still have two newlines
inbetween them, as expected.