### PR TITLE
fmtcmd: Remove extra newline

### DIFF
--- a/hcl/fmtcmd/fmtcmd.go
+++ b/hcl/fmtcmd/fmtcmd.go
@@ -60,8 +60,6 @@ func processFile(filename string, in io.Reader, out io.Writer, stdin bool, opts 
 	if err != nil {
 		return err
 	}
-	// Files should end with newlines
-	res = append(res, []byte("\n")...)
 
 	if !bytes.Equal(src, res) {
 		// formatting has changed

--- a/hcl/fmtcmd/fmtcmd_test.go
+++ b/hcl/fmtcmd/fmtcmd_test.go
@@ -1,4 +1,4 @@
-// +build -windows
+// +build !windows
 // TODO(jen20): These need fixing on Windows but fmt is not used right now
 // and red CI is making it harder to process other bugs, so ignore until
 // we get around to fixing them.


### PR DESCRIPTION
The fmtcmd tests weren't running before due to the same build tag
problem as #112, so didn't catch the fact that there was an extra
newline being added here, which is now doubled thanks to #112.

Fixing up the build tag reveals failing tests - removing the extra
newline fixes the tests.