### PR TITLE
hcl/fmtcmd: Clarify docs for Options.Diff

### DIFF
--- a/hcl/fmtcmd/fmtcmd.go
+++ b/hcl/fmtcmd/fmtcmd.go
@@ -25,7 +25,7 @@ var (
 type Options struct {
 	List  bool // list files whose formatting differs
 	Write bool // write result to (source) file instead of stdout
-	Diff  bool // display diffs instead of rewriting files
+	Diff  bool // display diffs of formatting changes
 }
 
 func isValidFile(f os.FileInfo, extensions []string) bool {


### PR DESCRIPTION
This description was originally copied straight from gofmt[0]. But as noted
in hashicorp/terraform#6343, the "instead of rewriting" suggests that it
disables the `Write` option, whereas it is possible to enable both.

[0]: https://golang.org/src/cmd/gofmt/gofmt.go#L31