### PR TITLE
Ignore field when tag is "-" when decoding structs

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -517,6 +517,12 @@ func (d *decoder) decodeStruct(name string, node ast.Node, result reflect.Value)
 		structType := structVal.Type()
 		for i := 0; i < structType.NumField(); i++ {
 			fieldType := structType.Field(i)
+			tagParts := strings.Split(fieldType.Tag.Get(tagName), ",")
+
+			// Ignore fields with tag name "-"
+			if tagParts[0] == "-" {
+				continue
+			}
 
 			if fieldType.Anonymous {
 				fieldKind := fieldType.Type.Kind()
@@ -531,7 +537,6 @@ func (d *decoder) decodeStruct(name string, node ast.Node, result reflect.Value)
 				// We have an embedded field. We "squash" the fields down
 				// if specified in the tag.
 				squash := false
-				tagParts := strings.Split(fieldType.Tag.Get(tagName), ",")
 				for _, tag := range tagParts[1:] {
 					if tag == "squash" {
 						squash = true

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -406,9 +406,12 @@ func TestDecode_flatMap(t *testing.T) {
 }
 
 func TestDecode_structure(t *testing.T) {
+	type Embedded interface{}
+
 	type V struct {
-		Key int
-		Foo string
+		Embedded `hcl:"-"`
+		Key      int
+		Foo      string
 	}
 
 	var actual V


### PR DESCRIPTION
Like encoding/json each exported struct field becomes a member of the object unless the field's tag is "-"