### PR TITLE
Skip a nil item during filtering

### DIFF
--- a/hcl/ast/ast.go
+++ b/hcl/ast/ast.go
@@ -56,7 +56,7 @@ func (o *ObjectList) Filter(keys ...string) *ObjectList {
 	var result ObjectList
 	for _, item := range o.Items {
 		// If there aren't enough keys, then ignore this
-		if len(item.Keys) < len(keys) {
+		if item == nil || len(item.Keys) < len(keys) {
 			continue
 		}
 


### PR DESCRIPTION
While testing vault-secure-intro, the config file had an undesired `=` in the config, which was causing a panic.

Wrong input causing panic:
environment = "aws" {
}

Correct input:
environment "aws" {
}

This is where the investigation lead to.
All the tests pass.