### PR TITLE
strconv: Fix escaped backslashes \\ in braces ${}

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -59,7 +59,12 @@ func TestDecode_interface(t *testing.T) {
 			"escape.hcl",
 			false,
 			map[string]interface{}{
-				"foo": "bar\"baz\\n",
+				"foo":          "bar\"baz\\n",
+				"qux":          "back\\slash",
+				"bar":          "new\nline",
+				"qax":          `slash\:colon`,
+				"nested":       `${HH\:mm\:ss}`,
+				"nestedquotes": `${"okay"}`,
 			},
 		},
 		{

--- a/hcl/strconv/quote.go
+++ b/hcl/strconv/quote.go
@@ -49,7 +49,8 @@ func Unquote(s string) (t string, err error) {
 	for len(s) > 0 {
 		// If we're starting a '${}' then let it through un-unquoted.
 		// Specifically: we don't unquote any characters within the `${}`
-		// section, except for escaped quotes, which we handle specifically.
+		// section, except for escaped quotes and escaped backslashes, which we
+		// handle specifically.
 		if s[0] == '$' && len(s) > 1 && s[1] == '{' {
 			buf = append(buf, '$', '{')
 			s = s[2:]
@@ -64,10 +65,12 @@ func Unquote(s string) (t string, err error) {
 
 				s = s[size:]
 
-				// We special case escaped double quotes in interpolations, converting
-				// them to straight double quotes.
+				// We special case escaped double quotes and escaped backslashes in
+				// interpolations, converting them to their unescaped equivalents.
 				if r == '\\' {
-					if q, _ := utf8.DecodeRuneInString(s); q == '"' {
+					q, _ := utf8.DecodeRuneInString(s)
+					switch q {
+					case '"', '\\':
 						continue
 					}
 				}

--- a/hcl/strconv/quote_test.go
+++ b/hcl/strconv/quote_test.go
@@ -39,6 +39,7 @@ var unquotetests = []unQuoteTest{
 	{`"${file(\"foo\")}"`, `${file("foo")}`},
 	{`"echo ${var.region}${element(split(",",var.zones),0)}"`,
 		`echo ${var.region}${element(split(",",var.zones),0)}`},
+	{`"${HH\\:mm\\:ss}"`, `${HH\:mm\:ss}`},
 }
 
 var misquoted = []string{

--- a/test-fixtures/escape.hcl
+++ b/test-fixtures/escape.hcl
@@ -1,1 +1,6 @@
 foo = "bar\"baz\\n"
+bar = "new\nline"
+qux = "back\\slash"
+qax = "slash\\:colon"
+nested = "${HH\\:mm\\:ss}"
+nestedquotes = "${\"okay\"}"


### PR DESCRIPTION
Fixes hashicorp/terraform#6359 and several
related issues by unescaping a double backslash within braces to a
single backslash.

This bumps into the bit of HIL that still hangs out in HCL - for values
that aren't interpolated, like Terraform's variable defaults - users
were unable to get a backslash to show up within `${}`.

That's because `${}` is handled specially to allow for, e.g., double
quotes inside of braces.

Here, we add `\\` as a special cased escape (along with `\"`) so users
can get backslashes in these scenarios by doubling them up.