### PR TITLE
hcl/scanner: handle \"\\0 input properly

### DIFF
--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -525,16 +525,25 @@ func (s *Scanner) scanEscape() rune {
 // scanDigits scans a rune with the given base for n times. For example an
 // octal notation \184 would yield in scanDigits(ch, 8, 3)
 func (s *Scanner) scanDigits(ch rune, base, n int) rune {
+	start := n
 	for n > 0 && digitVal(ch) < base {
 		ch = s.next()
+		if ch == eof {
+			break
+		}
+
 		n--
 	}
 	if n > 0 {
 		s.err("illegal char escape")
 	}
 
-	// we scanned all digits, put the last non digit char back
-	s.unread()
+	if n != start {
+		// we scanned all digits, put the last non digit char back,
+		// only if we read anything at all
+		s.unread()
+	}
+
 	return ch
 }
 

--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -529,6 +529,8 @@ func (s *Scanner) scanDigits(ch rune, base, n int) rune {
 	for n > 0 && digitVal(ch) < base {
 		ch = s.next()
 		if ch == eof {
+			// If we see an EOF, we halt any more scanning of digits
+			// immediately.
 			break
 		}
 

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -283,6 +283,11 @@ func TestPosition(t *testing.T) {
 	}
 }
 
+func TestNullChar(t *testing.T) {
+	s := New([]byte("\"\\0"))
+	s.Scan() // Used to panic
+}
+
 func TestComment(t *testing.T) {
 	testTokenList(t, tokenLists["comment"])
 }
@@ -378,7 +383,7 @@ func TestRealExample(t *testing.T) {
 Main interface
 EOF
 	    }
-	    
+
 		network_interface {
 	        device_index = 1
 	        description = <<-EOF


### PR DESCRIPTION
Fixes GH-127

As the title says.