### PR TITLE
json: interpolations have to be escaped

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -342,6 +342,14 @@ func TestDecode_interface(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"interpolate.json",
+			false,
+			map[string]interface{}{
+				"default": `${replace("europe-west", "-", " ")}`,
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/json/parser/parser_test.go
+++ b/json/parser/parser_test.go
@@ -315,6 +315,14 @@ func TestParse(t *testing.T) {
 			"bad_input_128.json",
 			true,
 		},
+		{
+			"bad_input_tf_8110.json",
+			true,
+		},
+		{
+			"good_input_tf_8110.json",
+			false,
+		},
 	}
 
 	const fixtureDir = "./test-fixtures"

--- a/json/parser/test-fixtures/bad_input_tf_8110.json
+++ b/json/parser/test-fixtures/bad_input_tf_8110.json
@@ -1,0 +1,7 @@
+{
+  "variable": {
+    "poc": {
+      "default": "${replace("europe-west", "-", " ")}"
+    }
+  }
+}

--- a/json/parser/test-fixtures/good_input_tf_8110.json
+++ b/json/parser/test-fixtures/good_input_tf_8110.json
@@ -1,0 +1,7 @@
+{
+  "variable": {
+    "poc": {
+      "default": "${replace(\"europe-west\", \"-\", \" \")}"
+    }
+  }
+}

--- a/json/scanner/scanner.go
+++ b/json/scanner/scanner.go
@@ -296,7 +296,7 @@ func (s *Scanner) scanString() {
 			return
 		}
 
-		if ch == '"' && braces == 0 {
+		if ch == '"' {
 			break
 		}
 

--- a/json/scanner/scanner_test.go
+++ b/json/scanner/scanner_test.go
@@ -32,7 +32,6 @@ var tokenLists = map[string][]tokenPair{
 		{token.STRING, `" "`},
 		{token.STRING, `"a"`},
 		{token.STRING, `"本"`},
-		{token.STRING, `"${file("foo")}"`},
 		{token.STRING, `"${file(\"foo\")}"`},
 		{token.STRING, `"\a"`},
 		{token.STRING, `"\b"`},

--- a/test-fixtures/interpolate.json
+++ b/test-fixtures/interpolate.json
@@ -1,0 +1,3 @@
+{
+  "default": "${replace(\"europe-west\", \"-\", \" \")}"
+}


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform/issues/8110

At some point we ignored the " in interpolations. We do this for HCL and
it is correct but this is invalid JSON syntax and for JSON we've always
had the stance that we have to escape them.

This shows up in HCL as normal unescaped (because it only escapes it for the purpose of JSON), as the test shows in decode_test.go.