### PR TITLE
hcl/scanner: single line '//' commments verify second '/'

### DIFF
--- a/hcl/ast/ast.go
+++ b/hcl/ast/ast.go
@@ -214,4 +214,5 @@ func (c *CommentGroup) Pos() token.Pos {
 // GoStringer
 //-------------------------------------------------------------------
 
-func (o *ObjectKey) GoString() string { return fmt.Sprintf("*%#v", *o) }
+func (o *ObjectKey) GoString() string  { return fmt.Sprintf("*%#v", *o) }
+func (o *ObjectList) GoString() string { return fmt.Sprintf("*%#v", *o) }

--- a/hcl/parser/parser_test.go
+++ b/hcl/parser/parser_test.go
@@ -398,13 +398,14 @@ func TestParse_inline(t *testing.T) {
 		{"v\nN{{}}", true},
 		{"v=/\n[,", true},
 		{"v=10kb", true},
+		{"v=/foo", true},
 	}
 
 	for _, tc := range cases {
 		t.Logf("Testing: %q", tc.Value)
-		_, err := Parse([]byte(tc.Value))
+		ast, err := Parse([]byte(tc.Value))
 		if (err != nil) != tc.Err {
-			t.Fatalf("Input: %q\n\nError: %s\n\nAST: %s", tc.Value, err)
+			t.Fatalf("Input: %q\n\nError: %s\n\nAST: %#v", tc.Value, err, ast)
 		}
 	}
 }

--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -224,6 +224,11 @@ func (s *Scanner) Scan() token.Token {
 func (s *Scanner) scanComment(ch rune) {
 	// single line comments
 	if ch == '#' || (ch == '/' && s.peek() != '*') {
+		if ch == '/' && s.peek() != '/' {
+			s.err("expected '/' for comment")
+			return
+		}
+
 		ch = s.next()
 		for ch != '\n' && ch >= 0 && ch != eof {
 			ch = s.next()

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -496,6 +496,7 @@ func TestError(t *testing.T) {
 	testError(t, `"abc`, "1:5", "literal not terminated", token.STRING)
 	testError(t, `"abc`+"\n", "2:1", "literal not terminated", token.STRING)
 	testError(t, `/*/`, "1:4", "comment not terminated", token.COMMENT)
+	testError(t, `/foo`, "1:1", "expected '/' for comment", token.COMMENT)
 }
 
 func testError(t *testing.T, src, pos, msg string, tok token.Type) {


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform/issues/8477

The way the scanner works '/ foo' was actually valid comment syntax.
This obviously is not what we want. This modifies the scanner to verify
that '//' comments in fact have the second '/'.