### PR TITLE
Revert "Skip a nil item during filtering"

### DIFF
--- a/hcl/ast/ast.go
+++ b/hcl/ast/ast.go
@@ -56,7 +56,7 @@ func (o *ObjectList) Filter(keys ...string) *ObjectList {
 	var result ObjectList
 	for _, item := range o.Items {
 		// If there aren't enough keys, then ignore this
-		if item == nil || len(item.Keys) < len(keys) {
+		if len(item.Keys) < len(keys) {
 			continue
 		}
 


### PR DESCRIPTION
Reverts hashicorp/hcl#121

See discussion and test case on #121.