### PR TITLE
json/parser: set Assign property when parsing object item

### DIFF
--- a/json/parser/parser.go
+++ b/json/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/hcl/ast"
+	hcltoken "github.com/hashicorp/hcl/hcl/token"
 	"github.com/hashicorp/hcl/json/scanner"
 	"github.com/hashicorp/hcl/json/token"
 )
@@ -103,6 +104,14 @@ func (p *Parser) objectItem() (*ast.ObjectItem, error) {
 
 	switch p.tok.Type {
 	case token.COLON:
+		pos := p.tok.Pos
+		o.Assign = hcltoken.Pos{
+			Filename: pos.Filename,
+			Offset:   pos.Offset,
+			Line:     pos.Line,
+			Column:   pos.Column,
+		}
+
 		o.Val, err = p.objectValue()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Without this patch the `json/parser.Parser` did not fill the `hcl/ast.ObjectItem.Assign` property resulting in missing assignment operators, visible when printing it using the `hcl/printer` package. Please look at following example code demonstrating the issue:

```go
package main

import (
  "os"

  "github.com/hashicorp/hcl/json/parser"
  "github.com/hashicorp/hcl/hcl/printer"
)

const input = `
{
  "a": "b"
}
`

func main() {
  ast, err := parser.Parse([]byte(input))
  if err != nil {
    panic(err)
  }

  err = printer.Fprint(os.Stdout, ast)
  if err != nil {
    panic(err)
  }
}

```

When executed, this program printed `"a" "b"` to stdout which is missing the `=` character.
With the patch applied, the output is the correct version: `"a" = "b"`