### PR TITLE
[DO NOT MERGE YET] hcl: don't escape ANYTHING in ${}, let lower layer handle it

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -63,7 +63,7 @@ func TestDecode_interface(t *testing.T) {
 				"qux":          "back\\slash",
 				"bar":          "new\nline",
 				"qax":          `slash\:colon`,
-				"nested":       `${HH\:mm\:ss}`,
+				"nested":       `${HH\\:mm\\:ss}`,
 				"nestedquotes": `${"\"stringwrappedinquotes\""}`,
 			},
 		},
@@ -355,6 +355,20 @@ func TestDecode_interface(t *testing.T) {
 			"block_assign.hcl",
 			true,
 			nil,
+		},
+
+		{
+			"escape_backslash.hcl",
+			false,
+			map[string]interface{}{
+				"output": []map[string]interface{}{
+					map[string]interface{}{
+						"one":  `${replace(var.sub_domain, ".", "\\.")}`,
+						"two":  `${replace(var.sub_domain, ".", "\\\\.")}`,
+						"many": `${replace(var.sub_domain, ".", "\\\\\\\\.")}`,
+					},
+				},
+			},
 		},
 	}
 

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -363,7 +363,7 @@ func TestRealExample(t *testing.T) {
 
 	provider "aws" {
 	  access_key = "foo"
-	  secret_key = "bar"
+	  secret_key = "${replace(var.foo, ".", "\\.")}"
 	}
 
 	resource "aws_security_group" "firewall" {
@@ -416,7 +416,7 @@ EOF
 		{token.STRING, `"foo"`},
 		{token.IDENT, `secret_key`},
 		{token.ASSIGN, `=`},
-		{token.STRING, `"bar"`},
+		{token.STRING, `"${replace(var.foo, ".", "\\.")}"`},
 		{token.RBRACE, `}`},
 		{token.IDENT, `resource`},
 		{token.STRING, `"aws_security_group"`},

--- a/hcl/strconv/quote.go
+++ b/hcl/strconv/quote.go
@@ -46,7 +46,7 @@ func Unquote(s string) (t string, err error) {
 	for len(s) > 0 {
 		// If we're starting a '${}' then let it through un-unquoted.
 		// Specifically: we don't unquote any characters within the `${}`
-		// section, except for escaped backslashes, which we handle specifically.
+		// section.
 		if s[0] == '$' && len(s) > 1 && s[1] == '{' {
 			buf = append(buf, '$', '{')
 			s = s[2:]
@@ -60,16 +60,6 @@ func Unquote(s string) (t string, err error) {
 				}
 
 				s = s[size:]
-
-				// We special case escaped backslashes in interpolations, converting
-				// them to their unescaped equivalents.
-				if r == '\\' {
-					q, _ := utf8.DecodeRuneInString(s)
-					switch q {
-					case '\\':
-						continue
-					}
-				}
 
 				n := utf8.EncodeRune(runeTmp[:], r)
 				buf = append(buf, runeTmp[:n]...)

--- a/hcl/strconv/quote_test.go
+++ b/hcl/strconv/quote_test.go
@@ -39,7 +39,7 @@ var unquotetests = []unQuoteTest{
 	{`"${file("\"foo\"")}"`, `${file("\"foo\"")}`},
 	{`"echo ${var.region}${element(split(",",var.zones),0)}"`,
 		`echo ${var.region}${element(split(",",var.zones),0)}`},
-	{`"${HH\\:mm\\:ss}"`, `${HH\:mm\:ss}`},
+	{`"${HH\\:mm\\:ss}"`, `${HH\\:mm\\:ss}`},
 }
 
 var misquoted = []string{

--- a/hcl/token/token_test.go
+++ b/hcl/token/token_test.go
@@ -51,6 +51,12 @@ func TestTokenValue(t *testing.T) {
 		{Token{Type: STRING, Text: `"foo"`}, "foo"},
 		{Token{Type: STRING, Text: `"foo\nbar"`}, "foo\nbar"},
 		{Token{Type: STRING, Text: `"${file("foo")}"`}, `${file("foo")}`},
+		{
+			Token{
+				Type: STRING,
+				Text: `"${replace("foo", ".", "\\.")}"`,
+			},
+			`${replace("foo", ".", "\\.")}`},
 		{Token{Type: HEREDOC, Text: "<<EOF\nfoo\nbar\nEOF"}, "foo\nbar"},
 	}
 

--- a/test-fixtures/escape_backslash.hcl
+++ b/test-fixtures/escape_backslash.hcl
@@ -1,0 +1,5 @@
+output {
+  one = "${replace(var.sub_domain, ".", "\\.")}"
+  two = "${replace(var.sub_domain, ".", "\\\\.")}"
+  many = "${replace(var.sub_domain, ".", "\\\\\\\\.")}"
+}


### PR DESCRIPTION
🚧  **DO NOT MERGE YET**  🚧 

This changes the behavior of HCL to _completely ignore any escape sequences within `${}`_. This is likely to break some configurations that used this. However, it resulted in more broken behavior if used with HIL. 

The prior behavior caused problems because HCL would escape some things (escaped backslashes) and then HIL would do the same, or error for syntax/unescaped reasons. This double escape caused most practical configs to not work at all.

This change is slated for Terraform 0.8 when we can introduce BC-incompat.
