### PR TITLE
missing fields when decoding JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 sudo: false
 language: go
-go: 1.5
+go: 1.7

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ fmt: generate
 	go fmt ./...
 
 test: generate
+	go get -t ./...
 	go test $(TEST) $(TESTARGS)
 
 generate:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,8 @@ install:
     go version
 
     go env
+
+    go get -t ./...
+
 build_script:
 - cmd: go test -v ./...

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1016,6 +1016,64 @@ func TestDecode_flattenedJSON(t *testing.T) {
 				},
 			},
 		},
+
+		{ // Nested objects, one with a sibling key, and one without
+			JSON: `
+{
+  "variable": {
+    "var_1": {
+      "default": {
+        "key1": "a",
+        "key2": "b"
+      }
+    },
+    "var_2": {
+      "description": "Described",
+      "default": {
+        "key1": "a",
+        "key2": "b"
+      }
+    }
+  }
+}
+			`,
+			Out: &[]map[string]interface{}{},
+			Expected: &[]map[string]interface{}{
+				{
+					"variable": []map[string]interface{}{
+						{
+							"var_1": []map[string]interface{}{
+								{
+									"default": []map[string]interface{}{
+										{
+											"key1": "a",
+											"key2": "b",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					"variable": []map[string]interface{}{
+						{
+							"var_2": []map[string]interface{}{
+								{
+									"description": "Described",
+									"default": []map[string]interface{}{
+										{
+											"key1": "a",
+											"key2": "b",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range cases {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -852,21 +852,25 @@ func TestDecode_topLevelKeys(t *testing.T) {
 	}
 }
 
-func TestDecode_structureMixedFields(t *testing.T) {
-	jsonConfig := `{
-  "vars": {
-    "var_1": {
-      "default": {
-        "key1": "a",
-        "key2": "b"
-      }
-    },
-    "var_2": {
-      "description": "an extra field is required",
-      "default": {
-        "key1": "a",
-        "key2": "b"
-      }
+func TestDecode_structureFlattened(t *testing.T) {
+	jsonA := `
+{
+  "var_1": {
+    "default": {
+      "key1": "a",
+      "key2": "b"
+    }
+  }
+}
+`
+
+	jsonB := `
+{
+  "var_2": {
+    "description": "an extra field is required",
+    "default": {
+      "key1": "a",
+      "key2": "b"
     }
   }
 }
@@ -878,26 +882,27 @@ func TestDecode_structureMixedFields(t *testing.T) {
 		Default     map[string]string
 	}
 
-	type Root struct {
-		Vars []*V
-	}
+	var vA, vB []*V
 
-	var r Root
-
-	err := Decode(&r, jsonConfig)
+	err := Decode(&vA, jsonA)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if len(r.Vars) != 2 {
-		t.Fatalf("expected 2 Vars, got %d", len(r.Vars))
+	err = Decode(&vB, jsonB)
+	if err != nil {
+		t.Fatalf("err: %s", err)
 	}
 
-	if r.Vars[1].Default == nil {
-		t.Fatalf("failed to decode Default field in %#v", r.Vars[1])
+	if len(vA) == 0 {
+		t.Fatal("failed to decode vA")
 	}
 
-	if !reflect.DeepEqual(r.Vars[0].Default, r.Vars[1].Default) {
-		t.Fatalf("defaults should match\n[0]: %#v\n[1]: %#v\n", r.Vars[0], r.Vars[1])
+	if len(vB) == 0 {
+		t.Fatal("failed to decode vB")
+	}
+
+	if !reflect.DeepEqual(vA[0].Default, vB[0].Default) {
+		t.Fatalf("defaults should match\n[0]: %#v\n[1]: %#v\n", vA[0], vB[0])
 	}
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -867,7 +867,7 @@ func TestDecode_structureFlattened(t *testing.T) {
 	jsonB := `
 {
   "var_2": {
-    "description": "an extra field is required",
+    "description": "Described",
     "default": {
       "key1": "a",
       "key2": "b"
@@ -876,6 +876,7 @@ func TestDecode_structureFlattened(t *testing.T) {
 }
 `
 
+	// make sure we can also correctly extract the Name key
 	type V struct {
 		Name        string `hcl:",key"`
 		Description string
@@ -888,21 +889,36 @@ func TestDecode_structureFlattened(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	if len(vA) != 1 {
+		t.Fatal("failed to decode jsonA")
+	}
 
 	err = Decode(&vB, jsonB)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	if len(vA) == 0 {
-		t.Fatal("failed to decode vA")
+	if len(vB) != 1 {
+		t.Fatal("failed to decode jsonB")
 	}
 
-	if len(vB) == 0 {
-		t.Fatal("failed to decode vB")
+	expectedA := []*V{
+		&V{
+			Name:    "var_1",
+			Default: map[string]string{"key1": "a", "key2": "b"},
+		},
+	}
+	expectedB := []*V{
+		&V{
+			Name:        "var_2",
+			Description: "Described",
+			Default:     map[string]string{"key1": "a", "key2": "b"},
+		},
 	}
 
-	if !reflect.DeepEqual(vA[0].Default, vB[0].Default) {
-		t.Fatalf("defaults should match\n[0]: %#v\n[1]: %#v\n", vA[0], vB[0])
+	if !reflect.DeepEqual(vA, expectedA) {
+		t.Fatalf("\nexpected: %#v\ngot: %#v\n", expectedA[0], vA[0])
+	}
+	if !reflect.DeepEqual(vB, expectedB) {
+		t.Fatalf("\nexpected: %#v\ngot: %#v\n", expectedB[0], vB[0])
 	}
 }


### PR DESCRIPTION
A single JSON object with a single key and value of a another object fails to decode.

