### PR TITLE
hcl/printer: file with only comments formats properly

### DIFF
--- a/hcl/parser/parser_test.go
+++ b/hcl/parser/parser_test.go
@@ -282,6 +282,29 @@ func TestObjectKey(t *testing.T) {
 	}
 }
 
+func TestCommentGroup(t *testing.T) {
+	var cases = []struct {
+		src    string
+		groups int
+	}{
+		{"# Hello\n# World", 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			p := newParser([]byte(tc.src))
+			file, err := p.Parse()
+			if err != nil {
+				t.Fatalf("parse error: %s", err)
+			}
+
+			if len(file.Comments) != tc.groups {
+				t.Fatalf("bad: %#v", file.Comments)
+			}
+		})
+	}
+}
+
 // Official HCL tests
 func TestParse(t *testing.T) {
 	cases := []struct {

--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -123,7 +123,10 @@ func (p *printer) output(n interface{}) []byte {
 
 					if comment.Pos().After(p.prev) && comment.Pos().Before(nextItem) {
 						// if we hit the end add newlines so we can print the comment
-						if index == len(t.Items) {
+						// we don't do this if prev is invalid which means the
+						// beginning of the file since the first comment should
+						// be at the first line.
+						if p.prev.IsValid() && index == len(t.Items) {
 							buf.Write([]byte{newline, newline})
 						}
 

--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -95,7 +95,6 @@ func (p *printer) collectComments(node ast.Node) {
 	}
 
 	sort.Sort(ByPosition(p.standaloneComments))
-
 }
 
 // output prints creates b printable HCL output and returns it.
@@ -104,11 +103,14 @@ func (p *printer) output(n interface{}) []byte {
 
 	switch t := n.(type) {
 	case *ast.File:
+		// File doesn't trace so we add the tracing here
+		defer un(trace(p, "File"))
 		return p.output(t.Node)
 	case *ast.ObjectList:
+		defer un(trace(p, "ObjectList"))
+
 		var index int
 		var nextItem token.Pos
-		var commented bool
 		for {
 			// TODO(arslan): refactor below comment printing, we have the same in objectType
 			for _, c := range p.standaloneComments {
@@ -140,7 +142,7 @@ func (p *printer) output(n interface{}) []byte {
 			}
 
 			buf.Write(p.output(t.Items[index]))
-			if !commented && index != len(t.Items)-1 {
+			if index != len(t.Items)-1 {
 				buf.Write([]byte{newline, newline})
 			}
 			index++

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -33,6 +33,7 @@ var data = []entry{
 	{"list.input", "list.golden"},
 	{"comment.input", "comment.golden"},
 	{"comment_aligned.input", "comment_aligned.golden"},
+	{"comment_newline.input", "comment_newline.golden"},
 	{"comment_standalone.input", "comment_standalone.golden"},
 	{"empty_block.input", "empty_block.golden"},
 	{"list_of_objects.input", "list_of_objects.golden"},

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -42,7 +42,9 @@ func TestFiles(t *testing.T) {
 	for _, e := range data {
 		source := filepath.Join(dataDir, e.source)
 		golden := filepath.Join(dataDir, e.golden)
-		check(t, source, golden)
+		t.Run(e.source, func(t *testing.T) {
+			check(t, source, golden)
+		})
 	}
 }
 

--- a/hcl/printer/testdata/comment_newline.golden
+++ b/hcl/printer/testdata/comment_newline.golden
@@ -1,0 +1,3 @@
+# Hello
+# World
+

--- a/hcl/printer/testdata/comment_newline.input
+++ b/hcl/printer/testdata/comment_newline.input
@@ -1,0 +1,2 @@
+# Hello
+# World


### PR DESCRIPTION
This adds a special case to find comments that are first in a file to not prefix it with newlines and a test case for this. No other tests fail.