### PR TITLE
hcl/{parser,printer}: track and print lead comments for list items

### DIFF
--- a/hcl/ast/ast.go
+++ b/hcl/ast/ast.go
@@ -156,7 +156,8 @@ func (o *ObjectKey) Pos() token.Pos {
 type LiteralType struct {
 	Token token.Token
 
-	// associated line comment, only when used in a list
+	// comment types, only used when in a list
+	LeadComment *CommentGroup
 	LineComment *CommentGroup
 }
 

--- a/hcl/parser/parser.go
+++ b/hcl/parser/parser.go
@@ -337,6 +337,12 @@ func (p *Parser) listType() (*ast.ListType, error) {
 				return nil, err
 			}
 
+			// If there is a lead comment, apply it
+			if p.leadComment != nil {
+				node.LeadComment = p.leadComment
+				p.leadComment = nil
+			}
+
 			l.Add(node)
 			needComma = true
 		case token.COMMA:

--- a/hcl/parser/parser_test.go
+++ b/hcl/parser/parser_test.go
@@ -152,6 +152,57 @@ func TestListOfMaps_requiresComma(t *testing.T) {
 	}
 }
 
+func TestListType_lineComment(t *testing.T) {
+	var literals = []struct {
+		src     string
+		comment []string
+	}{
+		{
+			`foo = [
+			1,
+			2, # bar
+			3,
+			]`,
+			[]string{"", "# bar", ""},
+		},
+	}
+
+	for _, l := range literals {
+		p := newParser([]byte(l.src))
+		item, err := p.objectItem()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		list, ok := item.Val.(*ast.ListType)
+		if !ok {
+			t.Fatalf("node should be of type LiteralType, got: %T", item.Val)
+		}
+
+		if len(list.List) != len(l.comment) {
+			t.Fatalf("bad: %d", len(list.List))
+		}
+
+		for i, li := range list.List {
+			lt := li.(*ast.LiteralType)
+			comment := l.comment[i]
+
+			if (lt.LineComment == nil) != (comment == "") {
+				t.Fatalf("bad: %s", lt)
+			}
+
+			if comment == "" {
+				continue
+			}
+
+			actual := lt.LineComment.List[0].Text
+			if actual != comment {
+				t.Fatalf("bad: %q %q", actual, comment)
+			}
+		}
+	}
+}
+
 func TestObjectType(t *testing.T) {
 	var literals = []struct {
 		src      string

--- a/hcl/parser/parser_test.go
+++ b/hcl/parser/parser_test.go
@@ -152,6 +152,58 @@ func TestListOfMaps_requiresComma(t *testing.T) {
 	}
 }
 
+func TestListType_leadComment(t *testing.T) {
+	var literals = []struct {
+		src     string
+		comment []string
+	}{
+		{
+			`foo = [
+			1,
+			# bar
+			2,
+			3,
+			]`,
+			[]string{"", "# bar", ""},
+		},
+	}
+
+	for _, l := range literals {
+		p := newParser([]byte(l.src))
+		item, err := p.objectItem()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		list, ok := item.Val.(*ast.ListType)
+		if !ok {
+			t.Fatalf("node should be of type LiteralType, got: %T", item.Val)
+		}
+
+		if len(list.List) != len(l.comment) {
+			t.Fatalf("bad: %d", len(list.List))
+		}
+
+		for i, li := range list.List {
+			lt := li.(*ast.LiteralType)
+			comment := l.comment[i]
+
+			if (lt.LeadComment == nil) != (comment == "") {
+				t.Fatalf("bad: %#v", lt)
+			}
+
+			if comment == "" {
+				continue
+			}
+
+			actual := lt.LeadComment.List[0].Text
+			if actual != comment {
+				t.Fatalf("bad: %q %q", actual, comment)
+			}
+		}
+	}
+}
+
 func TestListType_lineComment(t *testing.T) {
 	var literals = []struct {
 		src     string

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -33,6 +33,7 @@ var data = []entry{
 	{"list.input", "list.golden"},
 	{"comment.input", "comment.golden"},
 	{"comment_aligned.input", "comment_aligned.golden"},
+	{"comment_array.input", "comment_array.golden"},
 	{"comment_newline.input", "comment_newline.golden"},
 	{"comment_standalone.input", "comment_standalone.golden"},
 	{"empty_block.input", "empty_block.golden"},

--- a/hcl/printer/testdata/comment_array.golden
+++ b/hcl/printer/testdata/comment_array.golden
@@ -1,0 +1,10 @@
+banana = [
+  # I really want to comment this item in the array.
+  "a",
+
+  # This as well
+  "b",
+
+  "c", # And C
+  "d",
+]

--- a/hcl/printer/testdata/comment_array.input
+++ b/hcl/printer/testdata/comment_array.input
@@ -1,0 +1,10 @@
+banana = [
+  # I really want to comment this item in the array.
+  "a",
+
+  # This as well
+  "b",
+
+  "c", # And C
+  "d",
+]


### PR DESCRIPTION
This updates the parser to properly store lead comments on list items. These lead comments are then rendered properly within the printer. See the test case for details.