### PR TITLE
hcl/printer: multiline strings don't indent lines 2+

### DIFF
--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -195,7 +195,8 @@ func (p *printer) output(n interface{}) []byte {
 
 func (p *printer) literalType(lit *ast.LiteralType) []byte {
 	result := []byte(lit.Token.Text)
-	if lit.Token.Type == token.HEREDOC {
+	switch lit.Token.Type {
+	case token.HEREDOC:
 		// Clear the trailing newline from heredocs
 		if result[len(result)-1] == '\n' {
 			result = result[:len(result)-1]
@@ -203,6 +204,12 @@ func (p *printer) literalType(lit *ast.LiteralType) []byte {
 
 		// Poison lines 2+ so that we don't indent them
 		result = p.heredocIndent(result)
+	case token.STRING:
+		// If this is a multiline string, poison lines 2+ so we don't
+		// indent them.
+		if bytes.ContainsRune(result, '\n') {
+			result = p.heredocIndent(result)
+		}
 	}
 
 	return result

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -40,6 +40,7 @@ var data = []entry{
 	{"comment_standalone.input", "comment_standalone.golden"},
 	{"empty_block.input", "empty_block.golden"},
 	{"list_of_objects.input", "list_of_objects.golden"},
+	{"multiline_string.input", "multiline_string.golden"},
 }
 
 func TestFiles(t *testing.T) {

--- a/hcl/printer/testdata/multiline_string.golden
+++ b/hcl/printer/testdata/multiline_string.golden
@@ -1,0 +1,7 @@
+resource "null_resource" "some_command" {
+  provisioner "local-exec" {
+    command = "echo '
+some newlines
+and additonal output'"
+  }
+}

--- a/hcl/printer/testdata/multiline_string.input
+++ b/hcl/printer/testdata/multiline_string.input
@@ -1,0 +1,7 @@
+resource "null_resource" "some_command" {
+  provisioner "local-exec" {
+    command = "echo '
+some newlines
+and additonal output'"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/9859

For strings that have more than one line, we should not indent the
follow-up lines.