### PR TITLE
hcl/printer: multiline comments shouldn't indent lines 2+

### DIFF
--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -288,7 +288,7 @@ func (p *printer) objectType(o *ast.ObjectType) []byte {
 						buf.WriteByte(newline)
 					}
 
-					buf.Write(p.indent([]byte(comment.Text)))
+					buf.Write(p.indent(p.heredocIndent([]byte(comment.Text))))
 					buf.WriteByte(newline)
 					if index != len(o.List.Items) {
 						buf.WriteByte(newline) // do not print on the end

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -34,6 +34,7 @@ var data = []entry{
 	{"comment.input", "comment.golden"},
 	{"comment_aligned.input", "comment_aligned.golden"},
 	{"comment_array.input", "comment_array.golden"},
+	{"comment_multiline_indent.input", "comment_multiline_indent.golden"},
 	{"comment_multiline_no_stanza.input", "comment_multiline_no_stanza.golden"},
 	{"comment_multiline_stanza.input", "comment_multiline_stanza.golden"},
 	{"comment_newline.input", "comment_newline.golden"},

--- a/hcl/printer/testdata/comment_multiline_indent.golden
+++ b/hcl/printer/testdata/comment_multiline_indent.golden
@@ -1,0 +1,12 @@
+resource "provider" "resource" {
+  /*
+  SPACE_SENSITIVE_CODE = <<EOF
+yaml code:
+   foo: ""
+   bar: ""
+EOF
+  */
+  /*
+       OTHER
+                */
+}

--- a/hcl/printer/testdata/comment_multiline_indent.input
+++ b/hcl/printer/testdata/comment_multiline_indent.input
@@ -1,0 +1,13 @@
+resource "provider" "resource" {
+  /*
+  SPACE_SENSITIVE_CODE = <<EOF
+yaml code:
+   foo: ""
+   bar: ""
+EOF
+  */
+
+  /*
+       OTHER
+                */
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/6524

This makes it so that lines 2+ in a comment aren't indented when formatted. This fixes an issue where comments would just continue to indent infinitely.