### PR TITLE
Remove duplicate unit test

### DIFF
--- a/hcl/parser/parser_test.go
+++ b/hcl/parser/parser_test.go
@@ -63,10 +63,6 @@ func TestListType(t *testing.T) {
 			[]token.Type{},
 		},
 		{
-			`foo = ["123", 123]`,
-			[]token.Type{token.STRING, token.NUMBER},
-		},
-		{
 			`foo = [1,
 "string",
 <<EOF


### PR DESCRIPTION
Tiny change! Two unit test cases were testing parsing of the same list of literals.