### PR TITLE
Integrate HIL parsing into the decoder

### DIFF
--- a/test-fixtures/hil.hcl
+++ b/test-fixtures/hil.hcl
@@ -1,0 +1,5 @@
+string = "foo"
+int    = 1
+float  = 1.2
+bool   = true
+expr   = "a ${baz} b"

--- a/test-fixtures/hil.json
+++ b/test-fixtures/hil.json
@@ -1,0 +1,7 @@
+{
+    "string": "foo",
+    "int": 1,
+    "float": 1.2,
+    "bool": true,
+    "expr": "a ${baz} b"
+}


### PR DESCRIPTION
Previously the integration between HCL and HIL was very loose: HCL made some accommodations in its string parsing so that HIL's `${ ... }` sequences got passed through without any extra escaping, but otherwise ignored it.

Treating HIL as an entirely separate concern from HCL generally causes applications to decode the raw HIL expression source into a string variable and then pass it to the HIL parser, but then the HIL parser
doesn't get the context about where in the HCL source the expression is located.

To make it easier for calling applications to "do the right thing" when accepting HIL expressions from HCL, here we deepen slightly the integration such that a caller can provide a HIL `ast.Node`
and the HCL decoder will then automatically pass a corresponding string in the configuration to the HIL parser.

We also support literals of other primitive types and just return them as synthetic HIL literals, so that callers don't need to bend over backwards to handle the common case where a value can either be a literal primitive or a HIL expression.

This direct coupling between HCL and HIL represents an architectural change, but one that acknowledges that the primary use-case for HIL is being embedded in HCL, and makes it easier for calling applications to correctly report errors with HIL-in-HCL with the appropriate source position.

This change requires hashicorp/hil#37 .