### PR TITLE
hcl/parser: don't print "illegal"

### DIFF
--- a/hcl/parser/parser.go
+++ b/hcl/parser/parser.go
@@ -256,7 +256,10 @@ func (p *Parser) objectKey() ([]*ast.ObjectKey, error) {
 			keyCount++
 			keys = append(keys, &ast.ObjectKey{Token: p.tok})
 		case token.ILLEGAL:
-			fmt.Println("illegal")
+			return keys, &PosError{
+				Pos: p.tok.Pos,
+				Err: fmt.Errorf("illegal character"),
+			}
 		default:
 			return keys, &PosError{
 				Pos: p.tok.Pos,


### PR DESCRIPTION
We shouldn't output any text during parsing, that's just strange!

token.ILLEGAL happens when the scanner has an error. This error is
recorded in `scerr` during parsing which is eventually returned out.
Therefore, we handle the error properly. We can simply return a backup
error here in case we don't (scanner errors are checked first).