### PR TITLE
Modify new bytes.ContainsRune to backward compatible bytes.IndexRune

### DIFF
--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -207,7 +207,7 @@ func (p *printer) literalType(lit *ast.LiteralType) []byte {
 	case token.STRING:
 		// If this is a multiline string, poison lines 2+ so we don't
 		// indent them.
-		if bytes.ContainsRune(result, '\n') {
+		if bytes.IndexRune(result, '\n') >= 0 {
 			result = p.heredocIndent(result)
 		}
 	}


### PR DESCRIPTION
The purpose of this change is so that the code is valid in Go < 1.7. I am using hcl/printer in spf13/viper#287. It requires tests in Go < 1.7, so this prevents that from passage. I did a work around using build constraints, but it is pretty ugly. It would be much better without that workaround being required and there will be no impact on hcl. 