### PR TITLE
hcl/printer: newline after heredoc items in lists

### DIFF
--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -503,7 +503,16 @@ func (p *printer) list(l *ast.ListType) []byte {
 			val := p.output(item)
 			curLen := len(val)
 			buf.Write(p.indent(val))
-			buf.WriteString(",")
+
+			// if this item is a heredoc, then we output the comma on
+			// the next line. This is the only case this happens.
+			comma := []byte{','}
+			if lit, ok := item.(*ast.LiteralType); ok && lit.Token.Type == token.HEREDOC {
+				buf.WriteByte(newline)
+				comma = p.indent(comma)
+			}
+
+			buf.Write(comma)
 
 			if lit, ok := item.(*ast.LiteralType); ok && lit.LineComment != nil {
 				// if the next item doesn't have any comments, do not align

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -132,7 +132,7 @@ func format(src []byte) ([]byte, error) {
 
 	// make sure formatted output is syntactically correct
 	if _, err := parser.Parse(formatted); err != nil {
-		return nil, fmt.Errorf("parse: %s\n%s", err, src)
+		return nil, fmt.Errorf("parse: %s\n%s", err, formatted)
 	}
 
 	return formatted, nil

--- a/hcl/printer/testdata/list.golden
+++ b/hcl/printer/testdata/list.golden
@@ -25,3 +25,14 @@ foo = [
   "ethiopia",
   "columbia",
 ]
+
+foo = [
+  <<EOS
+one
+EOS
+  ,
+  <<EOS
+two
+EOS
+  ,
+]

--- a/hcl/printer/testdata/list.input
+++ b/hcl/printer/testdata/list.input
@@ -2,14 +2,14 @@ foo = ["fatih", "arslan"           ]
 
 foo = [        "bar", "qaz", ]
 
-foo = [             "zeynep", 
+foo = [             "zeynep",
 "arslan", ]
 
 foo = ["fatih", "zeynep",
 "arslan", ]
 
 foo = [
-	"vim-go", 
+	"vim-go",
 	"golang", "hcl"]
 
 foo = []
@@ -19,3 +19,14 @@ foo = [1,   2,3,       4]
 foo = [
 	"kenya",        "ethiopia",
 	"columbia"]
+
+foo = [
+    <<EOS
+one
+EOS
+,
+    <<EOS
+two
+EOS
+,
+    ]


### PR DESCRIPTION
This is a weird formatting edge case that looks ugly but is the only syntax to make this work. See: https://github.com/hashicorp/terraform/issues/10947