### PR TITLE
hcl: print single heredoc elements properly

### DIFF
--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -42,6 +42,7 @@ var data = []entry{
 	{"empty_block.input", "empty_block.golden"},
 	{"list_of_objects.input", "list_of_objects.golden"},
 	{"multiline_string.input", "multiline_string.golden"},
+	{"object_with_heredoc.input", "object_with_heredoc.golden"},
 }
 
 func TestFiles(t *testing.T) {

--- a/hcl/printer/testdata/list.golden
+++ b/hcl/printer/testdata/list.golden
@@ -37,9 +37,7 @@ EOS
   ,
 ]
 
-foo = [
-  <<EOS
+foo = [<<EOS
 one
 EOS
-  ,
 ]

--- a/hcl/printer/testdata/list.input
+++ b/hcl/printer/testdata/list.input
@@ -31,8 +31,7 @@ EOS
 ,
     ]
 
-foo = [
-    <<EOS
+foo = [<<EOS
 one
 EOS
     ]

--- a/hcl/printer/testdata/object_with_heredoc.golden
+++ b/hcl/printer/testdata/object_with_heredoc.golden
@@ -1,0 +1,6 @@
+obj {
+  foo = [<<EOF
+        TEXT!
+EOF
+  ]
+}

--- a/hcl/printer/testdata/object_with_heredoc.input
+++ b/hcl/printer/testdata/object_with_heredoc.input
@@ -1,0 +1,6 @@
+obj {
+    foo = [<<EOF
+        TEXT!
+EOF
+    ]
+}


### PR DESCRIPTION
https://github.com/hashicorp/terraform/issues/11208

This builds on #177 to support lists with a heredoc that is at the same line as the list bracket. See tests for example formatting.