### PR TITLE
hcl/printer: format comments across multiple lines in an object

### DIFF
--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -38,6 +38,7 @@ var data = []entry{
 	{"comment_multiline_no_stanza.input", "comment_multiline_no_stanza.golden"},
 	{"comment_multiline_stanza.input", "comment_multiline_stanza.golden"},
 	{"comment_newline.input", "comment_newline.golden"},
+	{"comment_object_multi.input", "comment_object_multi.golden"},
 	{"comment_standalone.input", "comment_standalone.golden"},
 	{"empty_block.input", "empty_block.golden"},
 	{"list_of_objects.input", "list_of_objects.golden"},

--- a/hcl/printer/testdata/comment_object_multi.golden
+++ b/hcl/printer/testdata/comment_object_multi.golden
@@ -1,0 +1,9 @@
+variable "environment" {
+  default = {}
+
+  # default {
+  #    "region" = "us-west-2"
+  #    "sg"     = "playground"
+  #    "env"    = "prod"
+  #  }
+}

--- a/hcl/printer/testdata/comment_object_multi.input
+++ b/hcl/printer/testdata/comment_object_multi.input
@@ -1,0 +1,9 @@
+variable "environment" {
+  default = {}
+
+  # default {
+  #    "region" = "us-west-2"
+  #    "sg"     = "playground"
+  #    "env"    = "prod"
+  #  }
+}


### PR DESCRIPTION
https://github.com/hashicorp/terraform/issues/11209

See the TF issue above for an example, and test cases for a fix. This
didn't affect any other formatting tests.