### PR TITLE
hcl/printer: format single line objects to not have newline between

### DIFF
--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -44,6 +44,7 @@ var data = []entry{
 	{"empty_block.input", "empty_block.golden"},
 	{"list_of_objects.input", "list_of_objects.golden"},
 	{"multiline_string.input", "multiline_string.golden"},
+	{"object_singleline.input", "object_singleline.golden"},
 	{"object_with_heredoc.input", "object_with_heredoc.golden"},
 }
 

--- a/hcl/printer/testdata/empty_block.golden
+++ b/hcl/printer/testdata/empty_block.golden
@@ -1,5 +1,4 @@
 variable "foo" {}
-
 variable "foo" {}
 
 variable "foo" {

--- a/hcl/printer/testdata/object_singleline.golden
+++ b/hcl/printer/testdata/object_singleline.golden
@@ -1,0 +1,20 @@
+variable "foo" {}
+variable "bar" {}
+variable "baz" {}
+
+variable "qux" {}
+
+variable "foo" {
+  foo = "bar"
+}
+
+variable "foo" {}
+
+# lead comment
+variable "bar" {}
+
+# Purposeful newline check below:
+
+variable "foo" {}
+
+variable "purposeful-newline" {}

--- a/hcl/printer/testdata/object_singleline.input
+++ b/hcl/printer/testdata/object_singleline.input
@@ -1,0 +1,16 @@
+variable "foo" {}
+variable "bar" {}
+variable "baz" {}
+
+variable "qux" {}
+variable "foo" { foo = "bar" }
+
+variable "foo" {}
+# lead comment
+variable "bar" {}
+
+# Purposeful newline check below:
+
+variable "foo" {}
+
+variable "purposeful-newline" {}


### PR DESCRIPTION
Fixes #161

See #161 and test cases for examples.