### PR TITLE
hcl/printer: cleaner handling of standalone comments at end of file

### DIFF
--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -134,6 +134,7 @@ func (p *printer) output(n interface{}) []byte {
 				// Go through all the comments in the group. The group
 				// should be printed together, not separated by double newlines.
 				printed := false
+				newlinePrinted := false
 				for _, comment := range c.List {
 					// We only care about comments after the previous item
 					// we've printed so that comments are printed in the
@@ -144,8 +145,9 @@ func (p *printer) output(n interface{}) []byte {
 						// we don't do this if prev is invalid which means the
 						// beginning of the file since the first comment should
 						// be at the first line.
-						if p.prev.IsValid() && index == len(t.Items) {
+						if !newlinePrinted && p.prev.IsValid() && index == len(t.Items) {
 							buf.Write([]byte{newline, newline})
+							newlinePrinted = true
 						}
 
 						// Write the actual comment.

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -35,6 +35,7 @@ var data = []entry{
 	{"comment.input", "comment.golden"},
 	{"comment_aligned.input", "comment_aligned.golden"},
 	{"comment_array.input", "comment_array.golden"},
+	{"comment_end_file.input", "comment_end_file.golden"},
 	{"comment_multiline_indent.input", "comment_multiline_indent.golden"},
 	{"comment_multiline_no_stanza.input", "comment_multiline_no_stanza.golden"},
 	{"comment_multiline_stanza.input", "comment_multiline_stanza.golden"},

--- a/hcl/printer/testdata/comment_end_file.golden
+++ b/hcl/printer/testdata/comment_end_file.golden
@@ -1,0 +1,6 @@
+resource "blah" "blah" {}
+
+//
+//
+//
+

--- a/hcl/printer/testdata/comment_end_file.input
+++ b/hcl/printer/testdata/comment_end_file.input
@@ -1,0 +1,5 @@
+resource "blah" "blah" {}
+
+//
+//
+//


### PR DESCRIPTION
https://github.com/hashicorp/terraform/issues/11585#issuecomment-276681290

This isn't perfect (leaves a dangling newline at the end of the file) but it looks a LOT better than previously. See the test cases for examples and the TF issue above, too.