### PR TITLE
hcl/printer: singleline objects followed by non-singleline need blank

### DIFF
--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -176,10 +176,23 @@ func (p *printer) output(n interface{}) []byte {
 				// Always write a newline to separate us from the next item
 				buf.WriteByte(newline)
 
-				// If the next item is an object that is exactly one line,
-				// then we don't output another newline.
+				// Need to determine if we're going to separate the next item
+				// with a blank line. The logic here is simple, though there
+				// are a few conditions:
+				//
+				//   1. The next object is more than one line away anyways,
+				//      so we need an empty line.
+				//
+				//   2. The next object is not a "single line" object, so
+				//      we need an empty line.
+				//
+				//   3. This current object is not a single line object,
+				//      so we need an empty line.
+				current := t.Items[index]
 				next := t.Items[index+1]
-				if next.Pos().Line != t.Items[index].Pos().Line+1 || !p.isSingleLineObject(next) {
+				if next.Pos().Line != t.Items[index].Pos().Line+1 ||
+					!p.isSingleLineObject(next) ||
+					!p.isSingleLineObject(current) {
 					buf.WriteByte(newline)
 				}
 			}

--- a/hcl/printer/testdata/object_singleline.golden
+++ b/hcl/printer/testdata/object_singleline.golden
@@ -13,6 +13,12 @@ variable "foo" {}
 # lead comment
 variable "bar" {}
 
+variable "foo" {
+  default = "bar"
+}
+
+variable "bar" {}
+
 # Purposeful newline check below:
 
 variable "foo" {}

--- a/hcl/printer/testdata/object_singleline.input
+++ b/hcl/printer/testdata/object_singleline.input
@@ -9,6 +9,9 @@ variable "foo" {}
 # lead comment
 variable "bar" {}
 
+variable "foo" { default = "bar" }
+variable "bar" {}
+
 # Purposeful newline check below:
 
 variable "foo" {}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/12017