### PR TITLE
Return an error instead of printing stray `illegal\n` to stdout.

### DIFF
--- a/json/parser/parser.go
+++ b/json/parser/parser.go
@@ -147,7 +147,7 @@ func (p *Parser) objectKey() ([]*ast.ObjectKey, error) {
 			// Done
 			return keys, nil
 		case token.ILLEGAL:
-			fmt.Println("illegal")
+			return nil, errors.New("illegal")
 		default:
 			return nil, fmt.Errorf("expected: STRING got: %s", p.tok.Type)
 		}


### PR DESCRIPTION
Encountered while running `hcl.Decode()` on a JSON blob.