### PR TITLE
[WIP] printer: Add support for external filters during Format

### DIFF
--- a/hcl/fmtcmd/fmtcmd_test.go
+++ b/hcl/fmtcmd/fmtcmd_test.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/hashicorp/hcl/testhelper"
 )
 
@@ -437,4 +438,24 @@ func renderFixtures(parent string) (path string, err error) {
 	}
 
 	return path, nil
+}
+
+func TestRunWithFormatter(t *testing.T) {
+	testFormatterSource := `
+variable "foo" {
+  default = "one"
+}
+`
+	testFormatterExpected := `variable "foo" {
+  default = "two"
+}
+`
+	in := bytes.NewBufferString(testFormatterSource)
+	actual := new(bytes.Buffer)
+	if err := Run(nil, nil, in, actual, Options{Filters: []printer.Filter{&testhelper.TestFilter{}}}); err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	if testFormatterExpected != actual.String() {
+		t.Fatalf("Expected %s, got %s", testFormatterExpected, actual.String())
+	}
 }

--- a/hcl/printer/printer.go
+++ b/hcl/printer/printer.go
@@ -14,6 +14,18 @@ var DefaultConfig = Config{
 	SpacesWidth: 2,
 }
 
+// Filter is an interface that allows external programs to alter HCL in-line as
+// it's being parsed for printing. This allows specific examples such as adding
+// or altering fields based on context-specific needs.
+type Filter interface {
+	// Filter should modify the supplied ast.File inline, returning an error if
+	// for some reason the process fails. This fails the formatter as well.
+	//
+	// Care should be taken to supply the filters in the order they are intended
+	// to be applied when passing them to the slice in Format.
+	Filter(*ast.File) error
+}
+
 // A Config node controls the output of Fprint.
 type Config struct {
 	SpacesWidth int // if set, it will use spaces instead of tabs for alignment
@@ -48,11 +60,18 @@ func Fprint(output io.Writer, node ast.Node) error {
 	return DefaultConfig.Fprint(output, node)
 }
 
-// Format formats src HCL and returns the result.
-func Format(src []byte) ([]byte, error) {
+// Format formats src HCL and returns the result. External programs can supply
+// a list of filters to directly alter the formatted output as well.
+func Format(src []byte, filters []Filter) ([]byte, error) {
 	node, err := parser.Parse(src)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, f := range filters {
+		if err := f.Filter(node); err != nil {
+			return nil, err
+		}
 	}
 
 	var buf bytes.Buffer

--- a/hcl/printer/testdata/object_filter.golden
+++ b/hcl/printer/testdata/object_filter.golden
@@ -1,0 +1,3 @@
+variable "foo" {
+  key = "two"
+}

--- a/hcl/printer/testdata/object_filter.input
+++ b/hcl/printer/testdata/object_filter.input
@@ -1,0 +1,3 @@
+variable "foo" {
+  key = "one"
+}

--- a/testhelper/filter.go
+++ b/testhelper/filter.go
@@ -1,0 +1,12 @@
+package testhelper
+
+import "github.com/hashicorp/hcl/hcl/ast"
+
+// TestFilter is a test filter for the printer.
+type TestFilter struct{}
+
+// Filter implements printer.Filter for TestFilter.
+func (f *TestFilter) Filter(n *ast.File) error {
+	n.Node.(*ast.ObjectList).Items[0].Val.(*ast.ObjectType).List.Items[0].Val.(*ast.LiteralType).Token.Text = "\"two\""
+	return nil
+}


### PR DESCRIPTION
This PR introduces the ability to pass in external filters to alter the
formatting process in a way specific to the tool that HCL is implemented
for. An example would be pre-populating fields in Terraform during
`terraform fmt`, such as the description fields for variables and outputs.

`printer.Filter` is specifically an interface - the downstream tool
supplies the `Filter` method, which carries out the necessary behaviour.

Also in this PR are some updates to docs for `Run` and `Options` in `fmtcmd`.