### PR TITLE
Fix data race in decodeStruct

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -573,7 +573,11 @@ func (d *decoder) decodeStruct(name string, node ast.Node, result reflect.Value)
 
 	// Compile the list of all the fields that we're going to be decoding
 	// from all the structs.
-	fields := make(map[*reflect.StructField]reflect.Value)
+	type field struct {
+		field reflect.StructField
+		val   reflect.Value
+	}
+	fields := []field{}
 	for len(structs) > 0 {
 		structVal := structs[0]
 		structs = structs[1:]
@@ -616,7 +620,7 @@ func (d *decoder) decodeStruct(name string, node ast.Node, result reflect.Value)
 			}
 
 			// Normal struct field, store it away
-			fields[&fieldType] = structVal.Field(i)
+			fields = append(fields, field{fieldType, structVal.Field(i)})
 		}
 	}
 
@@ -624,26 +628,27 @@ func (d *decoder) decodeStruct(name string, node ast.Node, result reflect.Value)
 	decodedFields := make([]string, 0, len(fields))
 	decodedFieldsVal := make([]reflect.Value, 0)
 	unusedKeysVal := make([]reflect.Value, 0)
-	for fieldType, field := range fields {
-		if !field.IsValid() {
+	for _, f := range fields {
+		field, fieldValue := f.field, f.val
+		if !fieldValue.IsValid() {
 			// This should never happen
 			panic("field is not valid")
 		}
 
 		// If we can't set the field, then it is unexported or something,
 		// and we just continue onwards.
-		if !field.CanSet() {
+		if !fieldValue.CanSet() {
 			continue
 		}
 
-		fieldName := fieldType.Name
+		fieldName := field.Name
 
-		tagValue := fieldType.Tag.Get(tagName)
+		tagValue := field.Tag.Get(tagName)
 		tagParts := strings.SplitN(tagValue, ",", 2)
 		if len(tagParts) >= 2 {
 			switch tagParts[1] {
 			case "decodedFields":
-				decodedFieldsVal = append(decodedFieldsVal, field)
+				decodedFieldsVal = append(decodedFieldsVal, fieldValue)
 				continue
 			case "key":
 				if item == nil {
@@ -654,10 +659,10 @@ func (d *decoder) decodeStruct(name string, node ast.Node, result reflect.Value)
 					}
 				}
 
-				field.SetString(item.Keys[0].Token.Value().(string))
+				fieldValue.SetString(item.Keys[0].Token.Value().(string))
 				continue
 			case "unusedKeys":
-				unusedKeysVal = append(unusedKeysVal, field)
+				unusedKeysVal = append(unusedKeysVal, fieldValue)
 				continue
 			}
 		}
@@ -684,7 +689,7 @@ func (d *decoder) decodeStruct(name string, node ast.Node, result reflect.Value)
 		// because we actually want the value.
 		fieldName = fmt.Sprintf("%s.%s", name, fieldName)
 		if len(prefixMatches.Items) > 0 {
-			if err := d.decode(fieldName, prefixMatches, field); err != nil {
+			if err := d.decode(fieldName, prefixMatches, fieldValue); err != nil {
 				return err
 			}
 		}
@@ -694,12 +699,12 @@ func (d *decoder) decodeStruct(name string, node ast.Node, result reflect.Value)
 				decodeNode = &ast.ObjectList{Items: ot.List.Items}
 			}
 
-			if err := d.decode(fieldName, decodeNode, field); err != nil {
+			if err := d.decode(fieldName, decodeNode, fieldValue); err != nil {
 				return err
 			}
 		}
 
-		decodedFields = append(decodedFields, fieldType.Name)
+		decodedFields = append(decodedFields, field.Name)
 	}
 
 	if len(decodedFieldsVal) > 0 {


### PR DESCRIPTION
Using `*reflect.StructField` as map key results in a data race. I honestly
do not understand why yet and can only reproduce this in the consul
codebase with high concurrency but this patch fixes it.

The same problem also exists in mitchellh/mapstructure.

See https://github.com/mitchellh/mapstructure/pull/101