### PR TITLE
Consider empty lines as indented

### DIFF
--- a/hcl/token/token.go
+++ b/hcl/token/token.go
@@ -191,7 +191,7 @@ func unindentHeredoc(heredoc string) string {
 
 	isIndented := true
 	for _, v := range lines {
-		if strings.HasPrefix(v, whitespacePrefix) {
+		if strings.HasPrefix(v, whitespacePrefix) || v == "" {
 			continue
 		}
 


### PR DESCRIPTION
I just discovered that it is possible to automatically unindent heredoc (even if it is not yet in the documentation #195). Nice feature.

However, if I declare something like that:
```
description = <<-EOF
    This is the fist line

    This is the second line
    EOF
```

It may not work because the empty line between the two lines may have its trailing blanks removed by the editor. It works only if the line starts with spaces.

To fix that problem, I suggest that you do not consider empty lines as unindented lines to avoid inconsistent behaviour.