### PR TITLE
scanner: Don't call unread() after reading EOF.

### DIFF
--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -552,7 +552,7 @@ func (s *Scanner) scanDigits(ch rune, base, n int) rune {
 		s.err("illegal char escape")
 	}
 
-	if n != start {
+	if n != start && ch != eof {
 		// we scanned all digits, put the last non digit char back,
 		// only if we read anything at all
 		s.unread()

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -593,6 +593,33 @@ func countNewlines(s string) int {
 	return n
 }
 
+func TestScanDigitsUnread(t *testing.T) {
+	cases := []string{
+		"M=0\"\\00",
+		"M=\"\\00",
+		"\"\\00",
+		"M=[\"\\00",
+		"U{\"\\00",
+		"\"\n{}#\n\"\\00",
+		"M=[[\"\\00",
+		"U{d=0\"\\U00",
+		"#\n\"\\x00",
+		"m=[[[\"\\00",
+	}
+
+	for _, c := range cases {
+		s := New([]byte(c))
+
+		for {
+			tok := s.Scan()
+			if tok.Type == token.EOF {
+				break
+			}
+			t.Logf("s.Scan() = %s", tok)
+		}
+	}
+}
+
 func TestScanHeredocRegexpCompile(t *testing.T) {
 	cases := []string{
 		"0\xe1\n<<ȸ\nhello\nworld\nȸ",
@@ -600,7 +627,6 @@ func TestScanHeredocRegexpCompile(t *testing.T) {
 
 	for _, c := range cases {
 		s := New([]byte(c))
-		fmt.Printf("START %q\n", c)
 
 		for {
 			tok := s.Scan()


### PR DESCRIPTION
For example, the (Go quoted) input `\"\\00` creates the following stack trace:

```
panic: bytes.Buffer: UnreadRune: previous operation was not a successful ReadRune

goroutine 1 [running]:
github.com/hashicorp/hcl/hcl/scanner.(*Scanner).unread(0xc420090270)
        gopath/src/github.com/hashicorp/hcl/hcl/scanner/scanner.go:112 +0x245
github.com/hashicorp/hcl/hcl/scanner.(*Scanner).scanDigits(0xc420090270, 0x0, 0x8, 0x3, 0x5c2005b740)
        gopath/src/github.com/hashicorp/hcl/hcl/scanner/scanner.go:557 +0x1ba
github.com/hashicorp/hcl/hcl/scanner.(*Scanner).scanEscape(0xc420090270, 0xc40000005c)
        gopath/src/github.com/hashicorp/hcl/hcl/scanner/scanner.go:520 +0x181
github.com/hashicorp/hcl/hcl/scanner.(*Scanner).scanString(0xc420090270)
        gopath/src/github.com/hashicorp/hcl/hcl/scanner/scanner.go:504 +0x2c3
github.com/hashicorp/hcl/hcl/scanner.(*Scanner).Scan(0xc420090270, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        gopath/src/github.com/hashicorp/hcl/hcl/scanner/scanner.go:172 +0x509
github.com/hashicorp/hcl/hcl/parser.(*Parser).scan(0xc42005bd18, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        gopath/src/github.com/hashicorp/hcl/hcl/parser/parser.go:448 +0xf4
github.com/hashicorp/hcl/hcl/parser.(*Parser).objectKey(0xc42005bd18, 0x530aa8, 0xc42005bd18, 0xc42005bd18, 0x18, 0x50f980)
        gopath/src/github.com/hashicorp/hcl/hcl/parser/parser.go:224 +0xca
github.com/hashicorp/hcl/hcl/parser.(*Parser).objectItem(0xc42005bd18, 0x0, 0x0, 0x0)
        gopath/src/github.com/hashicorp/hcl/hcl/parser/parser.go:150 +0xbf
github.com/hashicorp/hcl/hcl/parser.(*Parser).objectList(0xc42005bd18, 0xc42000e000, 0x0, 0x0, 0x0)
        gopath/src/github.com/hashicorp/hcl/hcl/parser/parser.go:88 +0x139
github.com/hashicorp/hcl/hcl/parser.(*Parser).Parse(0xc42005bd18, 0xc420090270, 0x200000, 0xc42005bce0)
        gopath/src/github.com/hashicorp/hcl/hcl/parser/parser.go:59 +0xf3
github.com/hashicorp/hcl/hcl/parser.Parse(0x7fca1fdd9000, 0x4, 0x200000, 0x8, 0x0, 0x0)
        gopath/src/github.com/hashicorp/hcl/hcl/parser/parser.go:46 +0x294
github.com/hashicorp/hcl/hcl/printer.Format(0x7fca1fdd9000, 0x4, 0x200000, 0x0, 0xc42005bef0, 0x464307, 0x4, 0xc42005bed0)
        gopath/src/github.com/hashicorp/hcl/hcl/printer/printer.go:53 +0x5b
```

Kudos to [dvyukov/go-fuzz](https://github.com/dvyukov/go-fuzz/) for finding this!