### PR TITLE
scanner: Update prevPos even when returning utf8.RuneError.

### DIFF
--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -74,20 +74,17 @@ func (s *Scanner) next() rune {
 		return eof
 	}
 
-	if ch == utf8.RuneError && size == 1 {
-		s.srcPos.Column++
-		s.srcPos.Offset += size
-		s.lastCharLen = size
-		s.err("illegal UTF-8 encoding")
-		return ch
-	}
-
 	// remember last position
 	s.prevPos = s.srcPos
 
 	s.srcPos.Column++
 	s.lastCharLen = size
 	s.srcPos.Offset += size
+
+	if ch == utf8.RuneError && size == 1 {
+		s.err("illegal UTF-8 encoding")
+		return ch
+	}
 
 	if ch == '\n' {
 		s.srcPos.Line++

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -589,3 +589,22 @@ func countNewlines(s string) int {
 	}
 	return n
 }
+
+func TestScanHeredocRegexpCompile(t *testing.T) {
+	cases := []string{
+		"0\xe1\n<<ȸ\nhello\nworld\nȸ",
+	}
+
+	for _, c := range cases {
+		s := New([]byte(c))
+		fmt.Printf("START %q\n", c)
+
+		for {
+			tok := s.Scan()
+			if tok.Type == token.EOF {
+				break
+			}
+			t.Logf("s.Scan() = %s", tok)
+		}
+	}
+}


### PR DESCRIPTION
This fixes an off-by-one error that's triggered by a combination of `next()` returning `utf8.RuneError` and `unread()` being called.

Without this fix, the provided unit test crashes, the the following stack trace. This is because the off-by-one error triggers the here-doc marker, which is a multi-byte unicode codepoint, to only be partially included in the regular expression, causing a regexp compile error.

```
panic: regexp: Compile("[[:space:]]*<\xc8\\z"): error parsing regexp: invalid UTF-8: `�\z`

goroutine 32 [running]:
testing.tRunner.func1(0xc4200cae10)
        /usr/lib/google-golang/src/testing/testing.go:742 +0x29d
panic(0x507a00, 0xc420290690)
        /usr/lib/google-golang/src/runtime/panic.go:505 +0x229
regexp.MustCompile(0xc420289e10, 0x10, 0xc420087680)
        /usr/lib/google-golang/src/regexp/regexp.go:240 +0x171
github.com/hashicorp/hcl/hcl/scanner.(*Scanner).scanHeredoc(0xc4200878c0)
        gopath/src/github.com/hashicorp/hcl/hcl/scanner/scanner.go:444 +0x3a9
github.com/hashicorp/hcl/hcl/scanner.(*Scanner).Scan(0xc4200878c0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        gopath/src/github.com/hashicorp/hcl/hcl/scanner/scanner.go:186 +0x3e5
```

Notice the off-by-one error in the regexp: the regular expression is not supposed to contain the `<` character. 

Kudos to [dvyukov/go-fuzz](https://github.com/dvyukov/go-fuzz/) for finding this!