### PR TITLE
printer, scanner: Don't produce unparsable output.

### DIFF
--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -147,3 +147,25 @@ func lineAt(text []byte, offs int) []byte {
 	}
 	return text[offs:i]
 }
+
+// TestFormatParsable ensures that the output of Format() is can be parsed again.
+func TestFormatValidOutput(t *testing.T) {
+	cases := []string{
+		"#\x00",
+		"#\ue123t",
+	}
+
+	for _, c := range cases {
+		f, err := Format([]byte(c))
+		if err != nil {
+			// ignore these failures, not all inputs are valid HCL.
+			t.Logf("Format(%q) = %v", c, err)
+			continue
+		}
+
+		if _, err := parser.Parse(f); err != nil {
+			t.Errorf("Format(%q) = %q; Parse(%q) = %v", c, f, f, err)
+			continue
+		}
+	}
+}

--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -100,6 +100,11 @@ func (s *Scanner) next() rune {
 		return eof
 	}
 
+	if ch == '\uE123' {
+		s.err("unicode code point U+E123 reserved for internal use")
+		return utf8.RuneError
+	}
+
 	// debug
 	// fmt.Printf("ch: %q, offset:column: %d:%d\n", ch, s.srcPos.Offset, s.srcPos.Column)
 	return ch

--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -95,8 +95,7 @@ func (s *Scanner) next() rune {
 		s.srcPos.Column = 0
 	}
 
-	// If we see a null character with data left, then that is an error
-	if ch == '\x00' && s.buf.Len() > 0 {
+	if ch == '\x00' {
 		s.err("unexpected null character (0x00)")
 		return eof
 	}

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -509,6 +509,7 @@ func TestScan_crlf(t *testing.T) {
 func TestError(t *testing.T) {
 	testError(t, "\x80", "1:1", "illegal UTF-8 encoding", token.ILLEGAL)
 	testError(t, "\xff", "1:1", "illegal UTF-8 encoding", token.ILLEGAL)
+	testError(t, "\uE123", "1:1", "unicode code point U+E123 reserved for internal use", token.ILLEGAL)
 
 	testError(t, "ab\x80", "1:3", "illegal UTF-8 encoding", token.IDENT)
 	testError(t, "abc\xff", "1:4", "illegal UTF-8 encoding", token.IDENT)

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -512,6 +512,8 @@ func TestError(t *testing.T) {
 
 	testError(t, "ab\x80", "1:3", "illegal UTF-8 encoding", token.IDENT)
 	testError(t, "abc\xff", "1:4", "illegal UTF-8 encoding", token.IDENT)
+	testError(t, "ab\x00", "1:3", "unexpected null character (0x00)", token.IDENT)
+	testError(t, "ab\x00\n", "1:3", "unexpected null character (0x00)", token.IDENT)
 
 	testError(t, `"ab`+"\x80", "1:4", "illegal UTF-8 encoding", token.STRING)
 	testError(t, `"abc`+"\xff", "1:5", "illegal UTF-8 encoding", token.STRING)


### PR DESCRIPTION
This changes fix two cases in which `printer.Format()` produced output that was not accepted by `parser.Parse()`:

1.  The input ends in `\x00`: the scanner accepted this, because nothing is following the null byte. The formatter, however, decides to add a newline at the end of the file, assuming that this would be a no-op. Upon re-parsing, the null byte is no longer the last character in the stream and produces an error.
1.  The input contains the U+E123 unicode codepoint: this codepoint is used internally by the formatter to do some postprocessing of the generated output. If the input contains that codepoint, the postprocessing removes semantically relevant information, for example the pound sign signifying the beginning of a comment. This leads to unparsable output.

I think that it's sane to refuse those inputs as "invalid" and I think it's very unlikely that this will break existing use-cases.