### PR TITLE
Fix broken formatting directives

### DIFF
--- a/hcl/ast/ast_test.go
+++ b/hcl/ast/ast_test.go
@@ -137,7 +137,7 @@ func TestWalkEquality(t *testing.T) {
 	}
 
 	if len(newNode.Items) != 2 {
-		t.Error("expected newNode length 2, got: %d", len(newNode.Items))
+		t.Errorf("expected newNode length 2, got: %d", len(newNode.Items))
 	}
 
 	expected := []string{
@@ -147,7 +147,7 @@ func TestWalkEquality(t *testing.T) {
 
 	for i, item := range newNode.Items {
 		if len(item.Keys) != 1 {
-			t.Error("expected keys newNode length 1, got: %d", len(item.Keys))
+			t.Errorf("expected keys newNode length 1, got: %d", len(item.Keys))
 		}
 
 		if item.Keys[0].Token.Text != expected[i] {

--- a/hcl/fmtcmd/fmtcmd_test.go
+++ b/hcl/fmtcmd/fmtcmd_test.go
@@ -46,7 +46,7 @@ func TestIsValidFile(t *testing.T) {
 		}
 
 		if res := isValidFile(file, fixtureExtensions); res != tc.Expected {
-			t.Errorf("want: %b, got: %b", tc.Expected, res)
+			t.Errorf("want: %t, got: %t", tc.Expected, res)
 		}
 	}
 }
@@ -86,7 +86,7 @@ func TestRunMultiplePaths(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 	if stdout.String() != expectedOut.String() {
-		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut, stdout)
+		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut.String(), stdout.String())
 	}
 }
 
@@ -132,7 +132,7 @@ func TestRunSubDirectories(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 	if stdout.String() != expectedOut.String() {
-		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut, stdout)
+		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut.String(), stdout.String())
 	}
 }
 
@@ -161,7 +161,7 @@ func TestRunStdin(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 	if !bytes.Equal(stdout.Bytes(), expectedOut.Bytes()) {
-		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut, stdout)
+		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut.String(), stdout.String())
 	}
 }
 
@@ -242,7 +242,7 @@ func TestRunNoOptions(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 	if stdout.String() != expectedOut.String() {
-		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut, stdout)
+		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut.String(), stdout.String())
 	}
 }
 
@@ -274,7 +274,7 @@ func TestRunList(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 	if stdout.String() != expectedOut.String() {
-		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut, stdout)
+		t.Errorf("stdout want:\n%s\ngot:\n%s", expectedOut.String(), stdout.String())
 	}
 }
 


### PR DESCRIPTION
It looks like Go 1.10 fails these. This makes the build green again.

/cc @mitchellh @jefferai 