### PR TITLE
printer: Fix handling of line comments in multi-line statements.

### DIFF
--- a/hcl/parser/parser.go
+++ b/hcl/parser/parser.go
@@ -205,6 +205,12 @@ func (p *Parser) objectItem() (*ast.ObjectItem, error) {
 		}
 	}
 
+	// key=#comment
+	// val
+	if p.lineComment != nil {
+		o.LineComment, p.lineComment = p.lineComment, nil
+	}
+
 	// do a look-ahead for line comment
 	p.scan()
 	if len(keys) > 0 && o.Val.Pos().Line == keys[0].Pos().Line && p.lineComment != nil {

--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -252,6 +252,14 @@ func (p *printer) objectItem(o *ast.ObjectItem) []byte {
 		}
 	}
 
+	// If key and val are on different lines, treat line comments like lead comments.
+	if o.LineComment != nil && o.Val.Pos().Line != o.Keys[0].Pos().Line {
+		for _, comment := range o.LineComment.List {
+			buf.WriteString(comment.Text)
+			buf.WriteByte(newline)
+		}
+	}
+
 	for i, k := range o.Keys {
 		buf.WriteString(k.Token.Text)
 		buf.WriteByte(blank)
@@ -265,7 +273,7 @@ func (p *printer) objectItem(o *ast.ObjectItem) []byte {
 
 	buf.Write(p.output(o.Val))
 
-	if o.Val.Pos().Line == o.Keys[0].Pos().Line && o.LineComment != nil {
+	if o.LineComment != nil && o.Val.Pos().Line == o.Keys[0].Pos().Line {
 		buf.WriteByte(blank)
 		for _, comment := range o.LineComment.List {
 			buf.WriteString(comment.Text)

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -153,6 +153,7 @@ func TestFormatValidOutput(t *testing.T) {
 	cases := []string{
 		"#\x00",
 		"#\ue123t",
+		"x=//\n0y=<<_\n_\n",
 		"Y=<<4\n4/\n\n\n/4/@=4/\n\n\n/4000000004\r\r\n00004\n",
 		"x=<<_\n_\r\r\n_\n",
 	}

--- a/hcl/printer/testdata/comment.golden
+++ b/hcl/printer/testdata/comment.golden
@@ -34,3 +34,6 @@ variable = {
 foo {
   bar = "fatih" // line comment 2 
 } // line comment 3
+
+// comment
+multiline = "assignment"

--- a/hcl/printer/testdata/comment.input
+++ b/hcl/printer/testdata/comment.input
@@ -35,3 +35,5 @@ foo {
     bar = "fatih"       // line comment 2 
 }        // line comment 3
 
+multiline = // comment
+"assignment"

--- a/hcl/printer/testdata/comment_crlf.input
+++ b/hcl/printer/testdata/comment_crlf.input
@@ -35,3 +35,5 @@ foo {
     bar = "fatih"       // line comment 2 
 }        // line comment 3
 
+multiline = // comment
+"assignment"


### PR DESCRIPTION
This fixes comment handling in situations such as:

```
everything = // comment
42
```

Previously the comment would "leak" to a later line, potentially disturbing heredoc markers (see the included test for a demonstration). 

Kudos to [dvyukov/go-fuzz](https://github.com/dvyukov/go-fuzz/) for finding this!