### PR TITLE
scanner: Improve regular expression in "scanner".scanHeredoc().

### DIFF
--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -154,6 +154,7 @@ func TestFormatValidOutput(t *testing.T) {
 		"#\x00",
 		"#\ue123t",
 		"Y=<<4\n4/\n\n\n/4/@=4/\n\n\n/4000000004\r\r\n00004\n",
+		"x=<<_\n_\r\r\n_\n",
 	}
 
 	for _, c := range cases {

--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -153,6 +153,7 @@ func TestFormatValidOutput(t *testing.T) {
 	cases := []string{
 		"#\x00",
 		"#\ue123t",
+		"Y=<<4\n4/\n\n\n/4/@=4/\n\n\n/4000000004\r\r\n00004\n",
 	}
 
 	for _, c := range cases {

--- a/hcl/printer/testdata/object_with_heredoc.golden
+++ b/hcl/printer/testdata/object_with_heredoc.golden
@@ -1,6 +1,7 @@
 obj {
   foo = [<<EOF
         TEXT!
+!!EOF
 EOF
   ]
 }

--- a/hcl/printer/testdata/object_with_heredoc.input
+++ b/hcl/printer/testdata/object_with_heredoc.input
@@ -1,6 +1,7 @@
 obj {
     foo = [<<EOF
         TEXT!
+!!EOF
 EOF
     ]
 }

--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -440,9 +440,9 @@ func (s *Scanner) scanHeredoc() {
 
 	var identRegexp *regexp.Regexp
 	if identBytes[0] == '-' {
-		identRegexp = regexp.MustCompile(fmt.Sprintf(`^[[:space:]]*%s\z`, identBytes[1:]))
+		identRegexp = regexp.MustCompile(fmt.Sprintf(`^[[:space:]]*%s\r*\z`, identBytes[1:]))
 	} else {
-		identRegexp = regexp.MustCompile(fmt.Sprintf(`^[[:space:]]*%s\z`, identBytes))
+		identRegexp = regexp.MustCompile(fmt.Sprintf(`^[[:space:]]*%s\r*\z`, identBytes))
 	}
 
 	// Read the actual string value

--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -440,9 +440,9 @@ func (s *Scanner) scanHeredoc() {
 
 	var identRegexp *regexp.Regexp
 	if identBytes[0] == '-' {
-		identRegexp = regexp.MustCompile(fmt.Sprintf(`[[:space:]]*%s\z`, identBytes[1:]))
+		identRegexp = regexp.MustCompile(fmt.Sprintf(`^[[:space:]]*%s\z`, identBytes[1:]))
 	} else {
-		identRegexp = regexp.MustCompile(fmt.Sprintf(`[[:space:]]*%s\z`, identBytes))
+		identRegexp = regexp.MustCompile(fmt.Sprintf(`^[[:space:]]*%s\z`, identBytes))
 	}
 
 	// Read the actual string value


### PR DESCRIPTION
This PR fixes two issues when parsing heredoc strings:

*   The regular expression was not anchored to the beginning of the line, allowing arbitrary garbage in front of the delimiter.
*   The regular expression did not accept an arbitrary number of cartridge returns. One optional cartridge return (`\r`) and one newline (`\n`) were considered a line break. If a line ends in multiple cartridge returns, e.g. `EOF\r\r\n`, it was not considered to end the heredoc string with delimiter `EOF`. However, the formatter removes one cartridge return, so that a repeated parsing *would* consider the same line to end the heredoc string, resulting in a different interpretation of the input.

    In most cases parsing the output results in a syntax error, but it is fairly easy to create inputs that change semantic due to formatting. For example,  `"x=<<_\n_\r\r\ny=1\nz=<<_\n_\n"` evaluates to `x = <string>` initially, but after reformatting it evaluates to `x = <string>, y = <int>, z = <string>`.

Kudos to [dvyukov/go-fuzz](https://github.com/dvyukov/go-fuzz/) for finding this!