### PR TITLE
scanner: Fix detection of zero-length heredoc anchor.

### DIFF
--- a/hcl/printer/printer_test.go
+++ b/hcl/printer/printer_test.go
@@ -155,6 +155,7 @@ func TestFormatValidOutput(t *testing.T) {
 		"#\ue123t",
 		"Y=<<4\n4/\n\n\n/4/@=4/\n\n\n/4000000004\r\r\n00004\n",
 		"x=<<_\n_\r\r\n_\n",
+		"X=<<-\n\r\r\n",
 	}
 
 	for _, c := range cases {

--- a/hcl/scanner/scanner.go
+++ b/hcl/scanner/scanner.go
@@ -433,7 +433,7 @@ func (s *Scanner) scanHeredoc() {
 
 	// Read the identifier
 	identBytes := s.src[offs : s.srcPos.Offset-s.lastCharLen]
-	if len(identBytes) == 0 {
+	if len(identBytes) == 0 || (len(identBytes) == 1 && identBytes[0] == '-') {
 		s.err("zero-length heredoc anchor")
 		return
 	}

--- a/hcl/scanner/scanner_test.go
+++ b/hcl/scanner/scanner_test.go
@@ -531,6 +531,9 @@ func TestError(t *testing.T) {
 	testError(t, `"${abc`+"\n", "2:1", "literal not terminated", token.STRING)
 	testError(t, `/*/`, "1:4", "comment not terminated", token.COMMENT)
 	testError(t, `/foo`, "1:1", "expected '/' for comment", token.COMMENT)
+
+	testError(t, "<<\nfoo\n\n", "1:3", "zero-length heredoc anchor", token.HEREDOC)
+	testError(t, "<<-\nfoo\n\n", "1:4", "zero-length heredoc anchor", token.HEREDOC)
 }
 
 func testError(t *testing.T, src, pos, msg string, tok token.Type) {


### PR DESCRIPTION
The existing check did not take into account that a leading `-` is not considered part of the anchor.