### PR TITLE
Heredoc accepts empty lines as if they were indented

### DIFF
--- a/hcl/token/token.go
+++ b/hcl/token/token.go
@@ -191,7 +191,7 @@ func unindentHeredoc(heredoc string) string {
 
 	isIndented := true
 	for _, v := range lines {
-		if strings.HasPrefix(v, whitespacePrefix) {
+		if v == "" || strings.HasPrefix(v, whitespacePrefix) {
 			continue
 		}
 

--- a/hcl/token/token_test.go
+++ b/hcl/token/token_test.go
@@ -57,7 +57,9 @@ func TestTokenValue(t *testing.T) {
 				Text: `"${replace("foo", ".", "\\.")}"`,
 			},
 			`${replace("foo", ".", "\\.")}`},
-		{Token{Type: HEREDOC, Text: "<<EOF\nfoo\nbar\nEOF"}, "foo\nbar"},
+		{Token{Type: HEREDOC, Text: "<<EOF\nfoo\nbar\nEOF\n"}, "foo\nbar\n"},
+		{Token{Type: HEREDOC, Text: "<<-EOF\n  \tfoo\n  \tbar\n  \tEOF\n"}, "foo\nbar\n"},
+		{Token{Type: HEREDOC, Text: "<<-EOF\n\tfoo\n\n\tbar\n\tEOF\n"}, "foo\n\nbar\n"},
 	}
 
 	for _, token := range tokens {


### PR DESCRIPTION
It also acknowledges the fact that unindentHeredoc always receives
heredoc with a trailing newline.

Closes #258 