### PR TITLE
Incorrect equivalent JSON example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ variable "ami" {
 This would be equivalent to the following json:
 ``` json
 {
-  "variable": {
-      "ami": {
+  "variable": [{
+      "ami": [{
           "description": "the AMI to use"
-        }
-    }
+        }]
+    }]
 }
 ```
 


### PR DESCRIPTION
Equivalent JSON example is incorrect as per issue #237

This causes a lot of frustration for folks building these objects programmatically. The error returned by terraform, for example, is particularly opaque, which means it could take days to discover this undocumented caveat.