### PR TITLE
Travis CI: The 'sudo' tag is now deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: go
 
 go:

--- a/hcl/parser/parser_test.go
+++ b/hcl/parser/parser_test.go
@@ -240,7 +240,7 @@ func TestListType_lineComment(t *testing.T) {
 			comment := l.comment[i]
 
 			if (lt.LineComment == nil) != (comment == "") {
-				t.Fatalf("bad: %s", lt)
+				t.Fatalf("bad: %#v", lt)
 			}
 
 			if comment == "" {


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

Lifted a fix from #267 to avoid failure https://travis-ci.org/hashicorp/hcl/jobs/494251211#L484-L485 when Travis CI tests are run on __go: tip__ as described in #271.