### PR TITLE
Decode string booleans

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -535,7 +535,7 @@ func (d *decoder) decodeString(name string, node ast.Node, result reflect.Value)
 	switch n := node.(type) {
 	case *ast.LiteralType:
 		switch n.Token.Type {
-		case token.NUMBER:
+		case token.NUMBER, token.FLOAT, token.BOOL:
 			result.Set(reflect.ValueOf(n.Token.Text).Convert(result.Type()))
 			return nil
 		case token.STRING, token.HEREDOC:

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -951,6 +951,28 @@ func TestDecode_float64(t *testing.T) {
 	}
 }
 
+func TestDecode_string(t *testing.T) {
+	type value struct {
+		A string `hcl:"a"`
+		B string `hcl:"b"`
+		C string `hcl:"c"`
+		D string `hcl:"d"`
+		E string `hcl:"e"`
+	}
+
+	got := value{}
+	err := Decode(&got, testReadFile(t, "string.hcl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := value{"s", "2", "2.718", "true", "false"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("expected %#v; got %#v", want, got)
+	}
+
+}
+
 func TestDecode_intStringAliased(t *testing.T) {
 	var value struct {
 		Count time.Duration

--- a/test-fixtures/string.hcl
+++ b/test-fixtures/string.hcl
@@ -1,0 +1,5 @@
+a = "s"
+b = 2
+c = 2.718
+d = true
+e = false


### PR DESCRIPTION
When we're decoding into a string value, convert the other literal types (FLOAT and BOOL) to strings as well. Previously, decoding would fail on an unexpected literal type.