### PR TITLE
Add tests to clarify heredoc behavior

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -107,6 +107,26 @@ func TestDecode_interface(t *testing.T) {
 			map[string]interface{}{"foo": "  bar\n  baz\n"},
 		},
 		{
+			"multiline_indented_aligned_with_newlines.hcl",
+			false,
+			map[string]interface{}{"foo": "        bar\n\n        baz\n        "},
+		},
+		{
+			"multiline_indented_aligned_with_newlines_and_tick.hcl",
+			false,
+			map[string]interface{}{"foo": "bar\n\nbaz\n"},
+		},
+		{
+			"multiline_indented_with_newlines.hcl",
+			false,
+			map[string]interface{}{"foo": "        bar\n\n        baz\n      "},
+		},
+		{
+			"multiline_indented_with_newlines_and_tick.hcl",
+			false,
+			map[string]interface{}{"foo": "  bar\n\n  baz\n"},
+		},
+		{
 			"multiline_no_hanging_indent.hcl",
 			false,
 			map[string]interface{}{"foo": "  baz\n    bar\n      foo\n"},

--- a/test-fixtures/multiline_indented_aligned_with_newlines.hcl
+++ b/test-fixtures/multiline_indented_aligned_with_newlines.hcl
@@ -1,0 +1,5 @@
+foo = <<EOF
+        bar
+
+        baz
+        EOF

--- a/test-fixtures/multiline_indented_aligned_with_newlines_and_tick.hcl
+++ b/test-fixtures/multiline_indented_aligned_with_newlines_and_tick.hcl
@@ -1,0 +1,5 @@
+foo = <<-EOF
+        bar
+
+        baz
+        EOF

--- a/test-fixtures/multiline_indented_with_newlines.hcl
+++ b/test-fixtures/multiline_indented_with_newlines.hcl
@@ -1,0 +1,5 @@
+foo = <<EOF
+        bar
+
+        baz
+      EOF

--- a/test-fixtures/multiline_indented_with_newlines_and_tick.hcl
+++ b/test-fixtures/multiline_indented_with_newlines_and_tick.hcl
@@ -1,0 +1,5 @@
+foo = <<-EOF
+        bar
+
+        baz
+      EOF


### PR DESCRIPTION
Some of these tests fail already, which is most certainly a mistake, because having a blank line shouldn't count as an un-indented line.

I don't know if the expected results are all correct, but it's better to codify this behavior as regression tests anyway, since it's an important and missing case.

I can edit the branch to whatever should be considered correct, but opening this PR is at least in part asking "what _should be_ considered correct?"