### PR TITLE
docs(ast): clarify comment on literal type

### DIFF
--- a/hcl/ast/ast.go
+++ b/hcl/ast/ast.go
@@ -151,8 +151,9 @@ func (o *ObjectKey) Pos() token.Pos {
 	return o.Token.Pos
 }
 
-// LiteralType represents a literal of basic type. Valid types are:
+// LiteralType represents a literal of basic type. Some valid types are:
 // token.NUMBER, token.FLOAT, token.BOOL and token.STRING
+// See 'token' package for more
 type LiteralType struct {
 	Token token.Token
 


### PR DESCRIPTION
This was a little confusing for me. I erroneously thought these three were the only literal types but HEREDOC and FLOAT are considered literals as well. Assuming the base 3 won't change and more may be added, it should be helpful to point people in the right direction.