### PR TITLE
Update specification file references in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ syntax allows use of arbitrary expressions within JSON strings:
 
 For more information, see the detailed specifications:
 
-* [Syntax-agnostic Information Model](hcl/spec.md)
-* [HCL Native Syntax](hcl/hclsyntax/spec.md)
-* [JSON Representation](hcl/json/spec.md)
+* [Syntax-agnostic Information Model](spec.md)
+* [HCL Native Syntax](hclsyntax/spec.md)
+* [JSON Representation](json/spec.md)
 
 ## Changes in 2.0
 


### PR DESCRIPTION
Excited to see the `hcl2` stuff merged into this repository. :tada: 

This tiny PR updates the link references to the `spec.md` files which used to exist under the `hcl/` directory in the hcl2 repository.