### PR TITLE
build: A basic appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+build: off
+
+clone_folder: c:\gopath\src\github.com\hashicorp\hcl
+
+environment:
+  GOPATH: c:\gopath
+  GO111MODULE: on
+  GOPROXY: https://goproxy.io
+
+stack: go 1.12
+
+test_script:
+  - go test ./...


### PR DESCRIPTION
In the long run we intend to transition to using CircleCI for all of the testing steps here, but we need to keep appveyor enabled here until we have both the HCL 1 and HCL 2 branches ready to use CircleCI, so this is just a minimal appveyor configuration for running our tests in a Windows environment in order to avoid errant test failures on PRs until we have completed the move fully to CircleCI.