### PR TITLE
hclwrite: Fix unstable list returned by Body.Blocks()

### DIFF
--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -60,7 +60,7 @@ func (b *Body) Attributes() map[string]*Attribute {
 // Blocks returns a new slice of all the blocks in the body.
 func (b *Body) Blocks() []*Block {
 	ret := make([]*Block, 0, len(b.items))
-	for n := range b.items {
+	for _, n := range b.items.List() {
 		if block, isBlock := n.content.(*Block); isBlock {
 			ret = append(ret, block)
 		}


### PR DESCRIPTION
Fixes #310

The type of `Body.items` is a `nodeSet` (That is, `map[*node]struct{}`),
so the order of the list returned by Body.Blocks () was unstable.