### PR TITLE
hclwrite: Allow constructing expressions from raw tokens

### DIFF
--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -134,6 +134,26 @@ func (b *Body) RemoveBlock(block *Block) bool {
 	return false
 }
 
+// SetAttributeRaw either replaces the expression of an existing attribute
+// of the given name or adds a new attribute definition to the end of the block,
+// using the given tokens verbatim as the expression.
+//
+// The same caveats apply to this function as for NewExpressionRaw on which
+// it is based. If possible, prefer to use SetAttributeValue or
+// SetAttributeTraversal.
+func (b *Body) SetAttributeRaw(name string, tokens Tokens) *Attribute {
+	attr := b.GetAttribute(name)
+	expr := NewExpressionRaw(tokens)
+	if attr != nil {
+		attr.expr = attr.expr.ReplaceWith(expr)
+	} else {
+		attr := newAttribute()
+		attr.init(name, expr)
+		b.appendItem(attr)
+	}
+	return attr
+}
+
 // SetAttributeValue either replaces the expression of an existing attribute
 // of the given name or adds a new attribute definition to the end of the block.
 //

--- a/hclwrite/ast_expression.go
+++ b/hclwrite/ast_expression.go
@@ -21,6 +21,29 @@ func newExpression() *Expression {
 	}
 }
 
+// NewExpressionRaw constructs an expression containing the given raw tokens.
+//
+// There is no automatic validation that the given tokens produce a valid
+// expression. Callers of thus function must take care to produce invalid
+// expression tokens. Where possible, use the higher-level functions
+// NewExpressionLiteral or NewExpressionAbsTraversal instead.
+//
+// Because NewExpressionRaw does not interpret the given tokens in any way,
+// an expression created by NewExpressionRaw will produce an empty result
+// for calls to its method Variables, even if the given token sequence
+// contains a subslice that would normally be interpreted as a traversal under
+// parsing.
+func NewExpressionRaw(tokens Tokens) *Expression {
+	expr := newExpression()
+	// We copy the tokens here in order to make sure that later mutations
+	// by the caller don't inadvertently cause our expression to become
+	// invalid.
+	copyTokens := make(Tokens, len(tokens))
+	copy(copyTokens, tokens)
+	expr.children.AppendUnstructuredTokens(copyTokens)
+	return expr
+}
+
 // NewExpressionLiteral constructs an an expression that represents the given
 // literal value.
 //


### PR DESCRIPTION
We currently have functions for constructing new expressions from either constant values or from traversals, but some surgical updates require producing a more complex expression.

In the long run perhaps we'll have some mechanism for constructing valid expressions via a high-level AST-like API, similar to what we already have for structural constructs, but as a simpler first step here we add a mechanism to just write raw tokens directly into an expression, with the caller being responsible for making sure those tokens represent valid HCL expression syntax.

Since this new API treats the given tokens as unstructured, the resulting expression can't fully support the whole of the expression API, but it's good enough for writing in complex expressions without disturbing existing content elsewhere in the input file.
