### PR TITLE
validate missed comma in json mode

### DIFF
--- a/json/parser/parser.go
+++ b/json/parser/parser.go
@@ -81,9 +81,9 @@ func (p *Parser) objectList() (*ast.ObjectList, error) {
 
 		node.Add(n)
 
-		// Check for a followup comma. If it isn't a comma, then we're done
+		// Check for a followup comma. If it isn't a comma, then returns an error
 		if tok := p.scan(); tok.Type != token.COMMA {
-			break
+			return node, fmt.Errorf("expected: COMMA got: %s", p.tok.Type)
 		}
 	}
 


### PR DESCRIPTION
Hi.
In the current json mode, if a comma after the value of ObjectType is missing, it will succeed in parsing by ignoring subsequent tokens.
```hcl
{
  "data_dir": "./tmpdata"  // missing comma
  "ports": {               // ignored
    "dns": 18600
  }
}
```
This often make us confusing because even though the parsing was successful, some fields were not loaded (ref. https://github.com/hashicorp/consul/issues/6209)
I think it's more friendly for developers to return an error in such cases. This PR lets it fail if comma is missing.

Please have a think about it, thank you.