### PR TITLE
Custom expression decoding in function calls and hcldec specs

### DIFF
--- a/ext/customdecode/README.md
+++ b/ext/customdecode/README.md
@@ -1,0 +1,209 @@
+# HCL Custom Static Decoding Extension
+
+This HCL extension provides a mechanism for defining arguments in an HCL-based
+language whose values are derived using custom decoding rules against the
+HCL expression syntax, overriding the usual behavior of normal expression
+evaluation.
+
+"Arguments", for the purpose of this extension, currently includes the
+following two contexts:
+
+* For applications using `hcldec` for dynamic decoding, a `hcldec.AttrSpec`
+  or `hcldec.BlockAttrsSpec` can be given a special type constraint that
+  opts in to custom decoding behavior for the attribute(s) that are selected
+  by that specification.
+
+* When working with the HCL native expression syntax, a function given in
+  the `hcl.EvalContext` during evaluation can have parameters with special
+  type constraints that opt in to custom decoding behavior for the argument
+  expression associated with that parameter in any call.
+
+The above use-cases are rather abstract, so we'll consider a motivating
+real-world example: sometimes we (language designers) need to allow users
+to specify type constraints directly in the language itself, such as in
+[Terraform's Input Variables](https://www.terraform.io/docs/configuration/variables.html).
+Terraform's `variable` blocks include an argument called `type` which takes
+a type constraint given using HCL expression building-blocks as defined by
+[the HCL `typeexpr` extension](../typeexpr/README.md).
+
+A "type constraint expression" of that sort is not an expression intended to
+be evaluated in the usual way. Instead, the physical expression is
+deconstructed using [the static analysis operations](../../spec.md#static-analysis)
+to produce a `cty.Type` as the result, rather than a `cty.Value`.
+
+The purpose of this Custom Static Decoding Extension, then, is to provide a
+bridge to allow that sort of custom decoding to be used via mechanisms that
+normally deal in `cty.Value`, such as `hcldec` and native syntax function
+calls as listed above.
+
+(Note: [`gohcl`](https://pkg.go.dev/github.com/hashicorp/hcl/v2/gohcl) has
+its own mechanism to support this use case, exploiting the fact that it is
+working directly with "normal" Go types. Decoding into a struct field of
+type `hcl.Expression` obtains the expression directly without evaluating it
+first. The Custom Static Decoding Extension is not necessary for that `gohcl`
+technique. You can also implement custom decoding by working directly with
+the lowest-level HCL API, which separates extraction of and evaluation of
+expressions into two steps.)
+
+## Custom Decoding Types
+
+This extension relies on a convention implemented in terms of
+[_Capsule Types_ in the underlying `cty` type system](https://github.com/zclconf/go-cty/blob/master/docs/types.md#capsule-types). `cty` allows a capsule type to carry arbitrary
+extension metadata values as an aid to creating higher-level abstractions like
+this extension.
+
+A custom argument decoding mode, then, is implemented by creating a new `cty`
+capsule type that implements the `ExtensionData` custom operation to return
+a decoding function when requested. For example:
+
+```go
+var keywordType cty.Type
+keywordType = cty.CapsuleWithOps("keyword", reflect.TypeOf(""), &cty.CapsuleOps{
+    ExtensionData: func(key interface{}) interface{} {
+        switch key {
+        case customdecode.CustomExpressionDecoder:
+            return customdecode.CustomExpressionDecoderFunc(
+                func(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+                    var diags hcl.Diagnostics
+                    kw := hcl.ExprAsKeyword(expr)
+                    if kw == "" {
+                        diags = append(diags, &hcl.Diagnostic{
+                            Severity: hcl.DiagError,
+                            Summary:  "Invalid keyword",
+                            Detail:   "A keyword is required",
+                            Subject:  expr.Range().Ptr(),
+                        })
+                        return cty.UnkownVal(keywordType), diags
+                    }
+                    return cty.CapsuleVal(keywordType, &kw)
+                },
+            )
+        default:
+            return nil
+        }
+    },
+})
+```
+
+The boilerplate here is a bit fussy, but the important part for our purposes
+is the `case customdecode.CustomExpressionDecoder:` clause, which uses
+a custom extension key type defined in this package to recognize when a
+component implementing this extension is checking to see if a target type
+has a custom decode implementation.
+
+In the above case we've defined a type that decodes expressions as static
+keywords, so a keyword like `foo` would decode as an encapsulated `"foo"`
+string, while any other sort of expression like `"baz"` or `1 + 1` would
+return an error.
+
+We could then use `keywordType` as a type constraint either for a function
+parameter or a `hcldec` attribute specification, which would require the
+argument for that function parameter or the expression for the matching
+attributes to be a static keyword, rather than an arbitrary expression.
+For example, in a `hcldec.AttrSpec`:
+
+```go
+keywordSpec := &hcldec.AttrSpec{
+    Name: "keyword",
+    Type: keywordType,
+}
+```
+
+The above would accept input like the following and would set its result to
+a `cty.Value` of `keywordType`, after decoding:
+
+```hcl
+keyword = foo
+```
+
+## The Expression and Expression Closure `cty` types
+
+Building on the above, this package also includes two capsule types that use
+the above mechanism to allow calling applications to capture expressions
+directly and thus defer analysis to a later step, after initial decoding.
+
+The `customdecode.ExpressionType` type encapsulates an `hcl.Expression` alone,
+for situations like our type constraint expression example above where it's
+the static structure of the expression we want to inspect, and thus any
+variables and functions defined in the evaluation context are irrelevant.
+
+The `customdecode.ExpressionClosureType` type encapsulates a
+`*customdecode.ExpressionClosure` value, which binds the given expression to
+the `hcl.EvalContext` it was asked to evaluate against and thus allows the
+receiver of that result to later perform normal evaluation of the expression
+with all the same variables and functions that would've been available to it
+naturally.
+
+Both of these types can be used as type constraints either for `hcldec`
+attribute specifications or for function arguments. Here's an example of
+`ExpressionClosureType` to implement a function that can evaluate
+an expression with some additional variables defined locally, which we'll
+call the `with(...)` function:
+
+```go
+var WithFunc = function.New(&function.Spec{
+    Params: []function.Parameter{
+        {
+            Name: "variables",
+            Type: cty.DynamicPseudoType,
+        },
+        {
+            Name: "expression",
+            Type: customdecode.ExpressionClosureType,
+        },
+    },
+    Type: func(args []cty.Value) (cty.Type, error) {
+        varsVal := args[0]
+        exprVal := args[1]
+        if !varsVal.Type().IsObjectType() {
+            return cty.NilVal, function.NewArgErrorf(0, "must be an object defining local variables")
+        }
+        if !varsVal.IsKnown() {
+            // We can't predict our result type until the variables object
+            // is known.
+            return cty.DynamicPseudoType, nil
+        }
+        vars := varsVal.AsValueMap()
+        closure := customdecode.ExpressionClosureFromVal(exprVal)
+        result, err := evalWithLocals(vars, closure)
+        if err != nil {
+            return cty.NilVal, err
+        }
+        return result.Type(), nil
+    },
+    Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+        varsVal := args[0]
+        exprVal := args[1]
+        vars := varsVal.AsValueMap()
+        closure := customdecode.ExpressionClosureFromVal(exprVal)
+        return evalWithLocals(vars, closure)
+    },
+})
+
+func evalWithLocals(locals map[string]cty.Value, closure *customdecode.ExpressionClosure) (cty.Value, error) {
+    childCtx := closure.EvalContext.NewChild()
+    childCtx.Variables = locals
+    val, diags := closure.Expression.Value(childCtx)
+    if diags.HasErrors() {
+        return cty.NilVal, function.NewArgErrorf(1, "couldn't evaluate expression: %s", diags.Error())
+    }
+    return val, nil
+}
+```
+
+If the above function were placed into an `hcl.EvalContext` as `with`, it
+could be used in a native syntax call to that function as follows:
+
+```hcl
+  foo = with({name = "Cory"}, "${greeting}, ${name}!")
+```
+
+The above assumes a variable in the main context called `greeting`, to which
+the `with` function adds `name` before evaluating the expression given in
+its second argument. This makes that second argument context-sensitive -- it
+would behave differently if the user wrote the same thing somewhere else -- so
+this capability should be used with care to make sure it doesn't cause confusion
+for the end-users of your language.
+
+There are some other examples of this capability to evaluate expressions in
+unusual ways in the `tryfunc` directory that is a sibling of this one.

--- a/ext/customdecode/customdecode.go
+++ b/ext/customdecode/customdecode.go
@@ -1,0 +1,56 @@
+// Package customdecode contains a HCL extension that allows, in certain
+// contexts, expression evaluation to be overridden by custom static analysis.
+//
+// This mechanism is only supported in certain specific contexts where
+// expressions are decoded with a specific target type in mind. For more
+// information, see the documentation on CustomExpressionDecoder.
+package customdecode
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type customDecoderImpl int
+
+// CustomExpressionDecoder is a value intended to be used as a cty capsule
+// type ExtensionData key for capsule types whose values are to be obtained
+// by static analysis of an expression rather than normal evaluation of that
+// expression.
+//
+// When a cooperating capsule type is asked for ExtensionData with this key,
+// it must return a non-nil CustomExpressionDecoderFunc value.
+//
+// This mechanism is not universally supported; instead, it's handled in a few
+// specific places where expressions are evaluated with the intent of producing
+// a cty.Value of a type given by the calling application.
+//
+// Specifically, this currently works for type constraints given in
+// hcldec.AttrSpec and hcldec.BlockAttrsSpec, and it works for arguments to
+// function calls in the HCL native syntax. HCL extensions implemented outside
+// of the main HCL module may also implement this; consult their own
+// documentation for details.
+const CustomExpressionDecoder = customDecoderImpl(1)
+
+// CustomExpressionDecoderFunc is the type of value that must be returned by
+// a capsule type handling the key CustomExpressionDecoder in its ExtensionData
+// implementation.
+//
+// If no error diagnostics are returned, the result value MUST be of the
+// capsule type that the decoder function was derived from. If the returned
+// error diagnostics prevent producing a value at all, return cty.NilVal.
+type CustomExpressionDecoderFunc func(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics)
+
+// CustomExpressionDecoderForType takes any cty type and returns its
+// custom expression decoder implementation if it has one. If it is not a
+// capsule type or it does not implement a custom expression decoder, this
+// function returns nil.
+func CustomExpressionDecoderForType(ty cty.Type) CustomExpressionDecoderFunc {
+	if !ty.IsCapsuleType() {
+		return nil
+	}
+	if fn, ok := ty.CapsuleExtensionData(CustomExpressionDecoder).(CustomExpressionDecoderFunc); ok {
+		return fn
+	}
+	return nil
+}

--- a/ext/customdecode/expression_type.go
+++ b/ext/customdecode/expression_type.go
@@ -1,0 +1,146 @@
+package customdecode
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ExpressionType is a cty capsule type that carries hcl.Expression values.
+//
+// This type implements custom decoding in the most general way possible: it
+// just captures whatever expression is given to it, with no further processing
+// whatsoever. It could therefore be useful in situations where an application
+// must defer processing of the expression content until a later step.
+//
+// ExpressionType only captures the expression, not the evaluation context it
+// was destined to be evaluated in. That means this type can be fine for
+// situations where the recipient of the value only intends to do static
+// analysis, but ExpressionClosureType is more appropriate in situations where
+// the recipient will eventually evaluate the given expression.
+var ExpressionType cty.Type
+
+// ExpressionVal returns a new cty value of type ExpressionType, wrapping the
+// given expression.
+func ExpressionVal(expr hcl.Expression) cty.Value {
+	return cty.CapsuleVal(ExpressionType, &expr)
+}
+
+// ExpressionFromVal returns the expression encapsulated in the given value, or
+// panics if the value is not a known value of ExpressionType.
+func ExpressionFromVal(v cty.Value) hcl.Expression {
+	if !v.Type().Equals(ExpressionType) {
+		panic("value is not of ExpressionType")
+	}
+	ptr := v.EncapsulatedValue().(*hcl.Expression)
+	return *ptr
+}
+
+// ExpressionClosureType is a cty capsule type that carries hcl.Expression
+// values along with their original evaluation contexts.
+//
+// This is similar to ExpressionType except that during custom decoding it
+// also captures the hcl.EvalContext that was provided, allowing callers to
+// evaluate the expression later in the same context where it would originally
+// have been evaluated, or a context derived from that one.
+var ExpressionClosureType cty.Type
+
+// ExpressionClosure is the type encapsulated in ExpressionClosureType
+type ExpressionClosure struct {
+	Expression  hcl.Expression
+	EvalContext *hcl.EvalContext
+}
+
+// ExpressionClosureVal returns a new cty value of type ExpressionClosureType,
+// wrapping the given expression closure.
+func ExpressionClosureVal(closure *ExpressionClosure) cty.Value {
+	return cty.CapsuleVal(ExpressionClosureType, closure)
+}
+
+// Value evaluates the closure's expression using the closure's EvalContext,
+// returning the result.
+func (c *ExpressionClosure) Value() (cty.Value, hcl.Diagnostics) {
+	return c.Expression.Value(c.EvalContext)
+}
+
+// ExpressionClosureFromVal returns the expression closure encapsulated in the
+// given value, or panics if the value is not a known value of
+// ExpressionClosureType.
+//
+// The caller MUST NOT modify the returned closure or the EvalContext inside
+// it. To derive a new EvalContext, either create a child context or make
+// a copy.
+func ExpressionClosureFromVal(v cty.Value) *ExpressionClosure {
+	if !v.Type().Equals(ExpressionClosureType) {
+		panic("value is not of ExpressionClosureType")
+	}
+	return v.EncapsulatedValue().(*ExpressionClosure)
+}
+
+func init() {
+	// Getting hold of a reflect.Type for hcl.Expression is a bit tricky because
+	// it's an interface type, but we can do it with some indirection.
+	goExpressionType := reflect.TypeOf((*hcl.Expression)(nil)).Elem()
+
+	ExpressionType = cty.CapsuleWithOps("expression", goExpressionType, &cty.CapsuleOps{
+		ExtensionData: func(key interface{}) interface{} {
+			switch key {
+			case CustomExpressionDecoder:
+				return CustomExpressionDecoderFunc(
+					func(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+						return ExpressionVal(expr), nil
+					},
+				)
+			default:
+				return nil
+			}
+		},
+		TypeGoString: func(_ reflect.Type) string {
+			return "customdecode.ExpressionType"
+		},
+		GoString: func(raw interface{}) string {
+			exprPtr := raw.(*hcl.Expression)
+			return fmt.Sprintf("customdecode.ExpressionVal(%#v)", *exprPtr)
+		},
+		RawEquals: func(a, b interface{}) bool {
+			aPtr := a.(*hcl.Expression)
+			bPtr := b.(*hcl.Expression)
+			return reflect.DeepEqual(*aPtr, *bPtr)
+		},
+	})
+	ExpressionClosureType = cty.CapsuleWithOps("expression closure", reflect.TypeOf(ExpressionClosure{}), &cty.CapsuleOps{
+		ExtensionData: func(key interface{}) interface{} {
+			switch key {
+			case CustomExpressionDecoder:
+				return CustomExpressionDecoderFunc(
+					func(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+						return ExpressionClosureVal(&ExpressionClosure{
+							Expression:  expr,
+							EvalContext: ctx,
+						}), nil
+					},
+				)
+			default:
+				return nil
+			}
+		},
+		TypeGoString: func(_ reflect.Type) string {
+			return "customdecode.ExpressionClosureType"
+		},
+		GoString: func(raw interface{}) string {
+			closure := raw.(*ExpressionClosure)
+			return fmt.Sprintf("customdecode.ExpressionClosureVal(%#v)", closure)
+		},
+		RawEquals: func(a, b interface{}) bool {
+			closureA := a.(*ExpressionClosure)
+			closureB := b.(*ExpressionClosure)
+			// The expression itself compares by deep equality, but EvalContexts
+			// conventionally compare by pointer identity, so we'll comply
+			// with both conventions here by testing them separately.
+			return closureA.EvalContext == closureB.EvalContext &&
+				reflect.DeepEqual(closureA.Expression, closureB.Expression)
+		},
+	})
+}

--- a/ext/tryfunc/README.md
+++ b/ext/tryfunc/README.md
@@ -1,0 +1,44 @@
+# "Try" and "can" functions
+
+This Go package contains two `cty` functions intended for use in an
+`hcl.EvalContext` when evaluating HCL native syntax expressions.
+
+The first function `try` attempts to evaluate each of its argument expressions
+in order until one produces a result without any errors.
+
+```hcl
+try(non_existent_variable, 2) # returns 2
+```
+
+If none of the expressions succeed, the function call fails with all of the
+errors it encountered.
+
+The second function `can` is similar except that it ignores the result of
+the given expression altogether and simply returns `true` if the expression
+produced a successful result or `false` if it produced errors.
+
+Both of these are primarily intended for working with deep data structures
+which might not have a dependable shape. For example, we can use `try` to
+attempt to fetch a value from deep inside a data structure but produce a
+default value if any step of the traversal fails:
+
+```hcl
+result = try(foo.deep[0].lots.of["traversals"], null)
+```
+
+The final result to `try` should generally be some sort of constant value that
+will always evaluate successfully.
+
+## Using these functions
+
+Languages built on HCL can make `try` and `can` available to user code by
+exporting them in the `hcl.EvalContext` used for expression evaluation:
+
+```go
+ctx := &hcl.EvalContext{
+    Functions: map[string]function.Function{
+        "try": tryfunc.TryFunc,
+        "can": tryfunc.CanFunc,
+    },
+}
+```

--- a/ext/tryfunc/tryfunc.go
+++ b/ext/tryfunc/tryfunc.go
@@ -1,0 +1,150 @@
+// Package tryfunc contains some optional functions that can be exposed in
+// HCL-based languages to allow authors to test whether a particular expression
+// can succeed and take dynamic action based on that result.
+//
+// These functions are implemented in terms of the customdecode extension from
+// the sibling directory "customdecode", and so they are only useful when
+// used within an HCL EvalContext. Other systems using cty functions are
+// unlikely to support the HCL-specific "customdecode" extension.
+package tryfunc
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/customdecode"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// TryFunc is a variadic function that tries to evaluate all of is arguments
+// in sequence until one succeeds, in which case it returns that result, or
+// returns an error if none of them succeed.
+var TryFunc function.Function
+
+// CanFunc tries to evaluate the expression given in its first argument.
+var CanFunc function.Function
+
+func init() {
+	TryFunc = function.New(&function.Spec{
+		VarParam: &function.Parameter{
+			Name: "expressions",
+			Type: customdecode.ExpressionClosureType,
+		},
+		Type: func(args []cty.Value) (cty.Type, error) {
+			v, err := try(args)
+			if err != nil {
+				return cty.NilType, err
+			}
+			return v.Type(), nil
+		},
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			return try(args)
+		},
+	})
+	CanFunc = function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name: "expression",
+				Type: customdecode.ExpressionClosureType,
+			},
+		},
+		Type: function.StaticReturnType(cty.Bool),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			return can(args[0])
+		},
+	})
+}
+
+func try(args []cty.Value) (cty.Value, error) {
+	if len(args) == 0 {
+		return cty.NilVal, errors.New("at least one argument is required")
+	}
+
+	// We'll collect up all of the diagnostics we encounter along the way
+	// and report them all if none of the expressions succeed, so that the
+	// user might get some hints on how to make at least one succeed.
+	var diags hcl.Diagnostics
+	for _, arg := range args {
+		closure := customdecode.ExpressionClosureFromVal(arg)
+		if dependsOnUnknowns(closure.Expression, closure.EvalContext) {
+			// We can't safely decide if this expression will succeed yet,
+			// and so our entire result must be unknown until we have
+			// more information.
+			return cty.DynamicVal, nil
+		}
+
+		v, moreDiags := closure.Value()
+		diags = append(diags, moreDiags...)
+		if moreDiags.HasErrors() {
+			continue // try the next one, if there is one to try
+		}
+		return v, nil // ignore any accumulated diagnostics if one succeeds
+	}
+
+	// If we fall out here then none of the expressions succeeded, and so
+	// we must have at least one diagnostic and we'll return all of them
+	// so that the user can see the errors related to whichever one they
+	// were expecting to have succeeded in this case.
+	//
+	// Because our function must return a single error value rather than
+	// diagnostics, we'll construct a suitable error message string
+	// that will make sense in the context of the function call failure
+	// diagnostic HCL will eventually wrap this in.
+	var buf strings.Builder
+	buf.WriteString("no expression succeeded:\n")
+	for _, diag := range diags {
+		if diag.Subject != nil {
+			buf.WriteString(fmt.Sprintf("- %s (at %s)\n  %s\n", diag.Summary, diag.Subject, diag.Detail))
+		} else {
+			buf.WriteString(fmt.Sprintf("- %s\n  %s\n", diag.Summary, diag.Detail))
+		}
+	}
+	buf.WriteString("\nAt least one expression must produce a successful result")
+	return cty.NilVal, errors.New(buf.String())
+}
+
+func can(arg cty.Value) (cty.Value, error) {
+	closure := customdecode.ExpressionClosureFromVal(arg)
+	if dependsOnUnknowns(closure.Expression, closure.EvalContext) {
+		// Can't decide yet, then.
+		return cty.UnknownVal(cty.Bool), nil
+	}
+
+	_, diags := closure.Value()
+	if diags.HasErrors() {
+		return cty.False, nil
+	}
+	return cty.True, nil
+}
+
+// dependsOnUnknowns returns true if any of the variables that the given
+// expression might access are unknown values or contain unknown values.
+//
+// This is a conservative result that prefers to return true if there's any
+// chance that the expression might derive from an unknown value during its
+// evaluation; it is likely to produce false-positives for more complex
+// expressions involving deep data structures.
+func dependsOnUnknowns(expr hcl.Expression, ctx *hcl.EvalContext) bool {
+	for _, traversal := range expr.Variables() {
+		val, diags := traversal.TraverseAbs(ctx)
+		if diags.HasErrors() {
+			// If the traversal returned a definitive error then it must
+			// not traverse through any unknowns.
+			continue
+		}
+		if !val.IsWhollyKnown() {
+			// The value will be unknown if either it refers directly to
+			// an unknown value or if the traversal moves through an unknown
+			// collection. We're using IsWhollyKnown, so this also catches
+			// situations where the traversal refers to a compound data
+			// structure that contains any unknown values. That's important,
+			// because during evaluation the expression might evaluate more
+			// deeply into this structure and encounter the unknowns.
+			return true
+		}
+	}
+	return false
+}

--- a/ext/tryfunc/tryfunc_test.go
+++ b/ext/tryfunc/tryfunc_test.go
@@ -1,0 +1,193 @@
+package tryfunc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+func TestTryFunc(t *testing.T) {
+	tests := map[string]struct {
+		expr    string
+		vars    map[string]cty.Value
+		want    cty.Value
+		wantErr string
+	}{
+		"one argument succeeds": {
+			`try(1)`,
+			nil,
+			cty.NumberIntVal(1),
+			``,
+		},
+		"two arguments, first succeeds": {
+			`try(1, 2)`,
+			nil,
+			cty.NumberIntVal(1),
+			``,
+		},
+		"two arguments, first fails": {
+			`try(nope, 2)`,
+			nil,
+			cty.NumberIntVal(2),
+			``,
+		},
+		"two arguments, first depends on unknowns": {
+			`try(unknown, 2)`,
+			map[string]cty.Value{
+				"unknown": cty.UnknownVal(cty.Number),
+			},
+			cty.DynamicVal, // can't proceed until first argument is known
+			``,
+		},
+		"two arguments, first succeeds and second depends on unknowns": {
+			`try(1, unknown)`,
+			map[string]cty.Value{
+				"unknown": cty.UnknownVal(cty.Number),
+			},
+			cty.NumberIntVal(1), // we know 1st succeeds, so it doesn't matter that 2nd is unknown
+			``,
+		},
+		"two arguments, first depends on unknowns deeply": {
+			`try(has_unknowns, 2)`,
+			map[string]cty.Value{
+				"has_unknowns": cty.ListVal([]cty.Value{cty.UnknownVal(cty.Bool)}),
+			},
+			cty.DynamicVal, // can't proceed until first argument is wholly known
+			``,
+		},
+		"two arguments, first traverses through an unkown": {
+			`try(unknown.baz, 2)`,
+			map[string]cty.Value{
+				"unknown": cty.UnknownVal(cty.Map(cty.String)),
+			},
+			cty.DynamicVal, // can't proceed until first argument is wholly known
+			``,
+		},
+		"three arguments, all fail": {
+			`try(this, that, this_thing_in_particular)`,
+			nil,
+			cty.NumberIntVal(2),
+			// The grammar of this stringification of the message is unfortunate,
+			// but caller can type-assert our result to get the original
+			// diagnostics directly in order to produce a better result.
+			`test.hcl:1,1-5: Error in function call; Call to function "try" failed: no expression succeeded:
+- Variables not allowed (at test.hcl:1,5-9)
+  Variables may not be used here.
+- Variables not allowed (at test.hcl:1,11-15)
+  Variables may not be used here.
+- Variables not allowed (at test.hcl:1,17-41)
+  Variables may not be used here.
+
+At least one expression must produce a successful result.`,
+		},
+		"no arguments": {
+			`try()`,
+			nil,
+			cty.NilVal,
+			`test.hcl:1,1-5: Error in function call; Call to function "try" failed: at least one argument is required.`,
+		},
+	}
+
+	for k, test := range tests {
+		t.Run(k, func(t *testing.T) {
+			expr, diags := hclsyntax.ParseExpression([]byte(test.expr), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+			if diags.HasErrors() {
+				t.Fatalf("unexpected problems: %s", diags.Error())
+			}
+
+			ctx := &hcl.EvalContext{
+				Variables: test.vars,
+				Functions: map[string]function.Function{
+					"try": TryFunc,
+				},
+			}
+
+			got, err := expr.Value(ctx)
+
+			if err != nil {
+				if test.wantErr != "" {
+					if got, want := err.Error(), test.wantErr; got != want {
+						t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+					}
+				} else {
+					t.Errorf("unexpected error\ngot:  %s\nwant: <nil>", err)
+				}
+				return
+			}
+			if test.wantErr != "" {
+				t.Errorf("wrong error\ngot:  <nil>\nwant: %s", test.wantErr)
+			}
+
+			if !test.want.RawEquals(got) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanFunc(t *testing.T) {
+	tests := map[string]struct {
+		expr string
+		vars map[string]cty.Value
+		want cty.Value
+	}{
+		"succeeds": {
+			`can(1)`,
+			nil,
+			cty.True,
+		},
+		"fails": {
+			`can(nope)`,
+			nil,
+			cty.False,
+		},
+		"simple unknown": {
+			`can(unknown)`,
+			map[string]cty.Value{
+				"unknown": cty.UnknownVal(cty.Number),
+			},
+			cty.UnknownVal(cty.Bool),
+		},
+		"traversal through unknown": {
+			`can(unknown.foo)`,
+			map[string]cty.Value{
+				"unknown": cty.UnknownVal(cty.Map(cty.Number)),
+			},
+			cty.UnknownVal(cty.Bool),
+		},
+		"deep unknown": {
+			`can(has_unknown)`,
+			map[string]cty.Value{
+				"has_unknown": cty.ListVal([]cty.Value{cty.UnknownVal(cty.Bool)}),
+			},
+			cty.UnknownVal(cty.Bool),
+		},
+	}
+
+	for k, test := range tests {
+		t.Run(k, func(t *testing.T) {
+			expr, diags := hclsyntax.ParseExpression([]byte(test.expr), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+			if diags.HasErrors() {
+				t.Fatalf("unexpected problems: %s", diags.Error())
+			}
+
+			ctx := &hcl.EvalContext{
+				Variables: test.vars,
+				Functions: map[string]function.Function{
+					"can": CanFunc,
+				},
+			}
+
+			got, err := expr.Value(ctx)
+			if err != nil {
+				t.Errorf("unexpected error\ngot:  %s\nwant: <nil>", err)
+			}
+			if !test.want.RawEquals(got) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/ext/typeexpr/type_type.go
+++ b/ext/typeexpr/type_type.go
@@ -1,0 +1,118 @@
+package typeexpr
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/customdecode"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// TypeConstraintType is a cty capsule type that allows cty type constraints to
+// be used as values.
+//
+// If TypeConstraintType is used in a context supporting the
+// customdecode.CustomExpressionDecoder extension then it will implement
+// expression decoding using the TypeConstraint function, thus allowing
+// type expressions to be used in contexts where value expressions might
+// normally be expected, such as in arguments to function calls.
+var TypeConstraintType cty.Type
+
+// TypeConstraintVal constructs a cty.Value whose type is
+// TypeConstraintType.
+func TypeConstraintVal(ty cty.Type) cty.Value {
+	return cty.CapsuleVal(TypeConstraintType, &ty)
+}
+
+// TypeConstraintFromVal extracts the type from a cty.Value of
+// TypeConstraintType that was previously constructed using TypeConstraintVal.
+//
+// If the given value isn't a known, non-null value of TypeConstraintType
+// then this function will panic.
+func TypeConstraintFromVal(v cty.Value) cty.Type {
+	if !v.Type().Equals(TypeConstraintType) {
+		panic("value is not of TypeConstraintType")
+	}
+	ptr := v.EncapsulatedValue().(*cty.Type)
+	return *ptr
+}
+
+// ConvertFunc is a cty function that implements type conversions.
+//
+// Its signature is as follows:
+//     convert(value, type_constraint)
+//
+// ...where type_constraint is a type constraint expression as defined by
+// typeexpr.TypeConstraint.
+//
+// It relies on HCL's customdecode extension and so it's not suitable for use
+// in non-HCL contexts or if you are using a HCL syntax implementation that
+// does not support customdecode for function arguments. However, it _is_
+// supported for function calls in the HCL native expression syntax.
+var ConvertFunc function.Function
+
+func init() {
+	TypeConstraintType = cty.CapsuleWithOps("type constraint", reflect.TypeOf(cty.Type{}), &cty.CapsuleOps{
+		ExtensionData: func(key interface{}) interface{} {
+			switch key {
+			case customdecode.CustomExpressionDecoder:
+				return customdecode.CustomExpressionDecoderFunc(
+					func(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+						ty, diags := TypeConstraint(expr)
+						if diags.HasErrors() {
+							return cty.NilVal, diags
+						}
+						return TypeConstraintVal(ty), nil
+					},
+				)
+			default:
+				return nil
+			}
+		},
+		TypeGoString: func(_ reflect.Type) string {
+			return "typeexpr.TypeConstraintType"
+		},
+		GoString: func(raw interface{}) string {
+			tyPtr := raw.(*cty.Type)
+			return fmt.Sprintf("typeexpr.TypeConstraintVal(%#v)", *tyPtr)
+		},
+		RawEquals: func(a, b interface{}) bool {
+			aPtr := a.(*cty.Type)
+			bPtr := b.(*cty.Type)
+			return (*aPtr).Equals(*bPtr)
+		},
+	})
+
+	ConvertFunc = function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name:             "value",
+				Type:             cty.DynamicPseudoType,
+				AllowNull:        true,
+				AllowDynamicType: true,
+			},
+			{
+				Name: "type",
+				Type: TypeConstraintType,
+			},
+		},
+		Type: func(args []cty.Value) (cty.Type, error) {
+			wantTypePtr := args[1].EncapsulatedValue().(*cty.Type)
+			got, err := convert.Convert(args[0], *wantTypePtr)
+			if err != nil {
+				return cty.NilType, function.NewArgError(0, err)
+			}
+			return got.Type(), nil
+		},
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			v, err := convert.Convert(args[0], retType)
+			if err != nil {
+				return cty.NilVal, function.NewArgError(0, err)
+			}
+			return v, nil
+		},
+	})
+}

--- a/ext/typeexpr/type_type_test.go
+++ b/ext/typeexpr/type_type_test.go
@@ -1,0 +1,118 @@
+package typeexpr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestTypeConstraintType(t *testing.T) {
+	tyVal1 := TypeConstraintVal(cty.String)
+	tyVal2 := TypeConstraintVal(cty.String)
+	tyVal3 := TypeConstraintVal(cty.Number)
+
+	if !tyVal1.RawEquals(tyVal2) {
+		t.Errorf("tyVal1 not equal to tyVal2\ntyVal1: %#v\ntyVal2: %#v", tyVal1, tyVal2)
+	}
+	if tyVal1.RawEquals(tyVal3) {
+		t.Errorf("tyVal1 equal to tyVal2, but should not be\ntyVal1: %#v\ntyVal3: %#v", tyVal1, tyVal3)
+	}
+
+	if got, want := TypeConstraintFromVal(tyVal1), cty.String; !got.Equals(want) {
+		t.Errorf("wrong type extracted from tyVal1\ngot:  %#v\nwant: %#v", got, want)
+	}
+	if got, want := TypeConstraintFromVal(tyVal3), cty.Number; !got.Equals(want) {
+		t.Errorf("wrong type extracted from tyVal3\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestConvertFunc(t *testing.T) {
+	// This is testing the convert function directly, skipping over the HCL
+	// parsing and evaluation steps that would normally lead there. There is
+	// another test in the "integrationtest" package called TestTypeConvertFunc
+	// that exercises the full path to this function via the hclsyntax parser.
+
+	tests := []struct {
+		val, ty cty.Value
+		want    cty.Value
+		wantErr string
+	}{
+		// The goal here is not an exhaustive set of conversions, since that's
+		// already covered in cty/convert, but rather exercising different
+		// permutations of success and failure to make sure the function
+		// handles all of the results in a reasonable way.
+		{
+			cty.StringVal("hello"),
+			TypeConstraintVal(cty.String),
+			cty.StringVal("hello"),
+			``,
+		},
+		{
+			cty.True,
+			TypeConstraintVal(cty.String),
+			cty.StringVal("true"),
+			``,
+		},
+		{
+			cty.StringVal("hello"),
+			TypeConstraintVal(cty.Bool),
+			cty.NilVal,
+			`a bool is required`,
+		},
+		{
+			cty.UnknownVal(cty.Bool),
+			TypeConstraintVal(cty.Bool),
+			cty.UnknownVal(cty.Bool),
+			``,
+		},
+		{
+			cty.DynamicVal,
+			TypeConstraintVal(cty.Bool),
+			cty.UnknownVal(cty.Bool),
+			``,
+		},
+		{
+			cty.NullVal(cty.Bool),
+			TypeConstraintVal(cty.Bool),
+			cty.NullVal(cty.Bool),
+			``,
+		},
+		{
+			cty.NullVal(cty.DynamicPseudoType),
+			TypeConstraintVal(cty.Bool),
+			cty.NullVal(cty.Bool),
+			``,
+		},
+		{
+			cty.StringVal("hello").Mark(1),
+			TypeConstraintVal(cty.String),
+			cty.StringVal("hello").Mark(1),
+			``,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%#v to %#v", test.val, test.ty), func(t *testing.T) {
+			got, err := ConvertFunc.Call([]cty.Value{test.val, test.ty})
+
+			if err != nil {
+				if test.wantErr != "" {
+					if got, want := err.Error(), test.wantErr; got != want {
+						t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+					}
+				} else {
+					t.Errorf("unexpected error\ngot:  %s\nwant: <nil>", err)
+				}
+				return
+			}
+			if test.wantErr != "" {
+				t.Errorf("wrong error\ngot:  <nil>\nwant: %s", test.wantErr)
+			}
+
+			if !test.want.RawEquals(got) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apparentlymart/go-textseg v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-test/deep v1.0.3
-	github.com/google/go-cmp v0.2.0
+	github.com/google/go-cmp v0.3.1
 	github.com/kr/pretty v0.1.0
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7
@@ -14,7 +14,7 @@ require (
 	github.com/sergi/go-diff v1.0.0
 	github.com/spf13/pflag v1.0.2
 	github.com/stretchr/testify v1.2.2 // indirect
-	github.com/zclconf/go-cty v1.1.1
+	github.com/zclconf/go-cty v1.2.0
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
-github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -29,8 +29,8 @@ github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/zclconf/go-cty v1.1.1 h1:Shl2p9Dat0cqJfXu0DZa+cOTRPhXQjK8IYWD6GVfiqo=
-github.com/zclconf/go-cty v1.1.1/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v1.2.0 h1:sPHsy7ADcIZQP3vILvTjrh74ZA175TFP5vqiNK1UmlI=
+github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/integrationtest/convertfunc_test.go
+++ b/integrationtest/convertfunc_test.go
@@ -1,0 +1,56 @@
+package integrationtest
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// TestTypeConvertFunc is an integration test of all of the layers involved
+// in making the type conversion function from ext/typeexpr work.
+//
+// This requires co-operation between the hclsyntax package, the ext/typeexpr
+// package, and the underlying cty functionality in order to work correctly.
+//
+// There are unit tests for the function implementation itself in the
+// ext/typeexpr package, so this test is focused on making sure the function
+// is given the opportunity to decode the second argument as a type expression
+// when the function is called from HCL native syntax.
+func TestTypeConvertFunc(t *testing.T) {
+	// The convert function is special because it takes a type expression
+	// rather than a value expression as its second argument. In this case,
+	// we're asking it to convert a tuple into a list of strings:
+	const exprSrc = `convert(["hello"], list(string))`
+	// It achieves this by marking that second argument as being of a custom
+	// type (a "capsule type", in cty terminology) that has a special
+	// annotation which hclsyntax.FunctionCallExpr understands as allowing
+	// the type to handle the analysis of the unevaluated expression, instead
+	// of evaluating it as normal.
+	//
+	// To see more details of how this works, look at the definitions of
+	// typexpr.TypeConstraintType and typeexpr.ConvertFunc, and at the
+	// implementation of hclsyntax.FunctionCallExpr.Value.
+
+	expr, diags := hclsyntax.ParseExpression([]byte(exprSrc), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected problems: %s", diags.Error())
+	}
+
+	ctx := &hcl.EvalContext{
+		Functions: map[string]function.Function{
+			"convert": typeexpr.ConvertFunc,
+		},
+	}
+	got, diags := expr.Value(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected problems: %s", diags.Error())
+	}
+	want := cty.ListVal([]cty.Value{cty.StringVal("hello")})
+	if !want.RawEquals(got) {
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+	}
+}

--- a/integrationtest/hcldec_into_expr_test.go
+++ b/integrationtest/hcldec_into_expr_test.go
@@ -1,0 +1,131 @@
+package integrationtest
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/customdecode"
+	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TestHCLDecDecodeToExpr tests both hcldec's support for types with custom
+// expression decoding rules and the two expression capsule types implemented
+// in ext/customdecode. This mechanism requires cooperation between those
+// two components and cty in order to work, so it's helpful to exercise it in
+// an integration test.
+func TestHCLDecDecodeToExpr(t *testing.T) {
+	// Here we're going to capture the structure of two simple expressions
+	// without immediately evaluating them.
+	const input = `
+a = foo
+b = foo
+c = "hello"
+`
+	// We'll capture "a" directly as an expression, losing its evaluation
+	// context but retaining its structure. We'll capture "b" as a
+	// customdecode.ExpressionClosure, which gives us both the expression
+	// itself and the evaluation context it was originally evaluated in.
+	// We also have "c" here just to make sure we can still decode into a
+	// "normal" type via standard expression evaluation.
+
+	f, diags := hclsyntax.ParseConfig([]byte(input), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected problems: %s", diags.Error())
+	}
+
+	spec := hcldec.ObjectSpec{
+		"a": &hcldec.AttrSpec{
+			Name:     "a",
+			Type:     customdecode.ExpressionType,
+			Required: true,
+		},
+		"b": &hcldec.AttrSpec{
+			Name:     "b",
+			Type:     customdecode.ExpressionClosureType,
+			Required: true,
+		},
+		"c": &hcldec.AttrSpec{
+			Name:     "c",
+			Type:     cty.String,
+			Required: true,
+		},
+	}
+	ctx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"foo": cty.StringVal("foo value"),
+		},
+	}
+	objVal, diags := hcldec.Decode(f.Body, spec, ctx)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected problems: %s", diags.Error())
+	}
+
+	aVal := objVal.GetAttr("a")
+	bVal := objVal.GetAttr("b")
+	cVal := objVal.GetAttr("c")
+
+	if got, want := aVal.Type(), customdecode.ExpressionType; !got.Equals(want) {
+		t.Fatalf("wrong type for 'a'\ngot:  %#v\nwant: %#v", got, want)
+	}
+	if got, want := bVal.Type(), customdecode.ExpressionClosureType; !got.Equals(want) {
+		t.Fatalf("wrong type for 'b'\ngot:  %#v\nwant: %#v", got, want)
+	}
+	if got, want := cVal.Type(), cty.String; !got.Equals(want) {
+		t.Fatalf("wrong type for 'c'\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	gotAExpr := customdecode.ExpressionFromVal(aVal)
+	wantAExpr := &hclsyntax.ScopeTraversalExpr{
+		Traversal: hcl.Traversal{
+			hcl.TraverseRoot{
+				Name: "foo",
+				SrcRange: hcl.Range{
+					Start: hcl.Pos{Line: 2, Column: 5, Byte: 5},
+					End:   hcl.Pos{Line: 2, Column: 8, Byte: 8},
+				},
+			},
+		},
+		SrcRange: hcl.Range{
+			Start: hcl.Pos{Line: 2, Column: 5, Byte: 5},
+			End:   hcl.Pos{Line: 2, Column: 8, Byte: 8},
+		},
+	}
+	if diff := cmp.Diff(wantAExpr, gotAExpr, cmpopts.IgnoreUnexported(hcl.TraverseRoot{})); diff != "" {
+		t.Errorf("wrong expression for a\n%s", diff)
+	}
+
+	bClosure := customdecode.ExpressionClosureFromVal(bVal)
+	gotBVal, diags := bClosure.Value()
+	wantBVal := cty.StringVal("foo value")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected problems: %s", diags.Error())
+	}
+	if got, want := gotBVal, wantBVal; !want.RawEquals(got) {
+		t.Errorf("wrong 'b' result\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	if got, want := cVal, cty.StringVal("hello"); !want.RawEquals(got) {
+		t.Errorf("wrong 'c'\ngot:  %#v\nwant: %#v", got, want)
+	}
+
+	// One additional "trick" we can do with the expression closure is to
+	// evaluate the expression in a _derived_ EvalContext, rather than the
+	// captured one. This could be useful for introducing additional local
+	// variables/functions in a particular context, for example.
+	deriveCtx := bClosure.EvalContext.NewChild()
+	deriveCtx.Variables = map[string]cty.Value{
+		"foo": cty.StringVal("overridden foo value"),
+	}
+	gotBVal2, diags := bClosure.Expression.Value(deriveCtx)
+	wantBVal2 := cty.StringVal("overridden foo value")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected problems: %s", diags.Error())
+	}
+	if got, want := gotBVal2, wantBVal2; !want.RawEquals(got) {
+		t.Errorf("wrong 'b' result with derived EvalContext\ngot:  %#v\nwant: %#v", got, want)
+	}
+}


### PR DESCRIPTION
These changes include some new capabilities for those building languages on top of HCL, but I'm going to start by talking about the main motivating use-cases that led me here, which all HCL functions that require some special handling for one or more of their arguments:

* `convert(value, type)` for generalized type conversion using a type expression instead of a value expression in the second argument, like `convert([], set(string))`. This can be useful when a value is being used as part of defining an API, like in [Terraform Output Values](https://www.terraform.io/docs/configuration/outputs.html), where we can be explicit about what result type we're intending and see an error if the value is not sufficiently close to that type to be converted successfully. (Terraform does already have functions like `toset(...)` which get partway there, but they don't allow explicitly specifying element/attribute types.)
* `try(expr, expr...)` for trying multiple expressions in sequence and taking the value of the first one that succeeds. This one is primarily useful for working with complex data structures of an unknown shape, for similar reasons as discussed in hashicorp/terraform#22460 but without introducing a whole new traversal syntax into the language.
* `can(expr)`, which is related to `try` but allows using the success or failure of the given expression as a boolean value to make other decisions.

These functions are all defined in extension packages, so merging them will not cause any change in behavior to any existing HCL caller immediately, but will allow each application to selectively opt-in to these if desired.

---

The underlying mechanism here is taking some inspiration from what is possible with both the low-level HCL API and with `gohcl`, where it's possible to access the structural `hcl.Expression` directly and perform arbitrary analyses on it either instead of or prior to evaluating it.

That sort of technique was previously unavailable in any situation which deals in `cty.Value` results, because there was no way to opt in to that special decoding in those contexts. Using an extension mechanism built in to `cty`'s "capsule types" mechanism, this introduces a new convention (whose public API is in `ext/customdecode`) of specifying a specially-annotated capsule type as a type constraint for an argument. This is approximately analogous to using custom named types and struct field tags in `gohcl`, but it's handled completely at runtime within `cty`'s type system instead.

There are some higher-level helpers here aiming to see that for common use-cases calling applications won't need to work directly with that low-level convention and can instead just work with cty types or cty functions already defined here for convenient use.

Perhaps the most interesting building block, which is the foundation of both `try(...)` and `can(...)`, is the `customdecode.ExpressionClosureType` capsule type: it allows any argument using it as a type constraint to capture both the physical expression _and_ the `EvalContext` that was passed to evaluate it. That means a function using this mechanism can delay evaluation of the expression while still retaining all of the same variables and functions that were available to it at original evaluation.

By analogy to the `gohcl` features using special types and struct tags, this custom decoding only applies to "argument-like" contexts, which for our purposes here is defined as the following to locations:

* `hcldec` attribute specifications whose type constraints are suitably-annotated capsule types, likewise allowing an attribute expression to be treated as raw syntax rather than as a value. (This is the closest analog to the equivalent `gohcl` capabilities, which Terraform uses for its special arguments like `depends_on`, input variable `type` arguments, etc.)
* Arguments to function calls, where the corresponding parameter has a type constraint that is a suitably-annotated capsule type, allowing a function to treat one of its arguments as raw syntax rather than as a value. This is a new capability, but is _conceptually_ similar to custom handling of attribute expressions.

Applications that have no need for these special capabilities can completely ignore them, by not importing any of the extension packages defined here. Although there are some small modifications to function call handling and `hcldec` decoding, those codepaths cannot be visited unless the calling program activates them through the featuers of these extension packages.
