### PR TITLE
hclwrite: handle legacy dot access of numeric indexes

### DIFF
--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -556,6 +556,69 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			"a = foo.0\n",
+			TestTreeNode{
+				Type: "Body",
+				Children: []TestTreeNode{
+					{
+						Type: "Attribute",
+						Children: []TestTreeNode{
+							{
+								Type: "comments",
+							},
+							{
+								Type: "identifier",
+								Val:  "a",
+							},
+							{
+								Type: "Tokens",
+								Val:  " =",
+							},
+							{
+								Type: "Expression",
+								Children: []TestTreeNode{
+									{
+										Type: "Traversal",
+										Children: []TestTreeNode{
+											{
+												Type: "TraverseName",
+												Children: []TestTreeNode{
+													{
+														Type: "identifier",
+														Val:  " foo",
+													},
+												},
+											},
+											{
+												Type: "TraverseIndex",
+												Children: []TestTreeNode{
+													{
+														Type: "Tokens",
+														Val:  ".",
+													},
+													{
+														Type: "number",
+														Val:  "0",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Type: "comments",
+							},
+							{
+								Type: "Tokens",
+								Val:  "\n",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"a = foo[bar]\n",
 			TestTreeNode{
 				Type: "Body",

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -691,6 +691,91 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			"a = foo[bar.baz]\n",
+			TestTreeNode{
+				Type: "Body",
+				Children: []TestTreeNode{
+					{
+						Type: "Attribute",
+						Children: []TestTreeNode{
+							{
+								Type: "comments",
+							},
+							{
+								Type: "identifier",
+								Val:  "a",
+							},
+							{
+								Type: "Tokens",
+								Val:  " =",
+							},
+							{
+								Type: "Expression",
+								Children: []TestTreeNode{
+									{
+										Type: "Traversal",
+										Children: []TestTreeNode{
+											{
+												Type: "TraverseName",
+												Children: []TestTreeNode{
+													{
+														Type: "identifier",
+														Val:  " foo",
+													},
+												},
+											},
+										},
+									},
+									{
+										Type: "Tokens",
+										Val:  "[",
+									},
+									{
+										Type: "Traversal",
+										Children: []TestTreeNode{
+											{
+												Type: "TraverseName",
+												Children: []TestTreeNode{
+													{
+														Type: "identifier",
+														Val:  "bar",
+													},
+												},
+											},
+											{
+												Type: "TraverseName",
+												Children: []TestTreeNode{
+													{
+														Type: "Tokens",
+														Val:  ".",
+													},
+													{
+														Type: "identifier",
+														Val:  "baz",
+													},
+												},
+											},
+										},
+									},
+									{
+										Type: "Tokens",
+										Val:  "]",
+									},
+								},
+							},
+							{
+								Type: "comments",
+							},
+							{
+								Type: "Tokens",
+								Val:  "\n",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"a = foo[bar].baz\n",
 			TestTreeNode{
 				Type: "Body",


### PR DESCRIPTION
This PR allows `hclwriter` to handle dot syntax for index accesses, e.g.:

```hcl
module "test" {
  test = kubernetes_config_map.test.metadata.0.name
}
```

Previously, attempting to partition on an open bracket caused a panic:

https://github.com/hashicorp/hcl/blob/hcl2/hclwrite/parser.go#L408

This PR adds a `PartitionTypeOk` that is a copy of `PartitionType`. It returns the same values, plus an `ok` bool  signifying that the token type was found. Otherwise, it returns zero-value `inputTokens` objects and a `false` boolean indicating that a partition token could not be found.

The approach to detecting that a traversal is `.#` style is admittedly fairly naive. However, adding a passing test on `a = foo[bar.baz]` makes me feel a bit more confident. 

Related bug reports:

https://github.com/apparentlymart/terraform-clean-syntax/issues/5
https://github.com/bendrucker/terraform-cloud-migrate/issues/3

I tested a copy of this patch and confirmed that it resolves the second report.

Thank you for all your work here, it has been a joy to develop on! Looking forward to contributing more.