### PR TITLE
Add tokens.Equal method for use in tests or for usage detection

### DIFF
--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -2,7 +2,6 @@ package hclwrite
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -1516,7 +1515,7 @@ bar {}
 		},
 	}
 	format(got)
-	if !reflect.DeepEqual(got, want) {
+	if !got.Equal(want, false) {
 		diff := cmp.Diff(want, got)
 		t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(want), diff)
 	}
@@ -1581,7 +1580,7 @@ bar {}
 		},
 	}
 	format(got)
-	if !reflect.DeepEqual(got, want) {
+	if !got.Equal(want, false) {
 		diff := cmp.Diff(want, got)
 		t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(want), diff)
 	}

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -209,7 +209,7 @@ func TestBodyGetAttribute(t *testing.T) {
 				}
 
 				got := attr.BuildTokens(nil)
-				if !reflect.DeepEqual(got, test.want) {
+				if !got.Equal(test.want, false) {
 					t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(got), spew.Sdump(test.want))
 				}
 			}
@@ -532,7 +532,7 @@ func TestBodySetAttributeValue(t *testing.T) {
 			f.Body().SetAttributeValue(test.name, test.val)
 			got := f.BuildTokens(nil)
 			format(got)
-			if !reflect.DeepEqual(got, test.want) {
+			if !got.Equal(test.want, false) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
 			}
@@ -758,7 +758,7 @@ func TestBodySetAttributeTraversal(t *testing.T) {
 			f.Body().SetAttributeTraversal(test.name, traversal)
 			got := f.BuildTokens(nil)
 			format(got)
-			if !reflect.DeepEqual(got, test.want) {
+			if !got.Equal(test.want, false) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
 			}
@@ -922,7 +922,7 @@ func TestBodySetAttributeRaw(t *testing.T) {
 			f.Body().SetAttributeRaw(test.name, test.tokens)
 			got := f.BuildTokens(nil)
 			format(got)
-			if !reflect.DeepEqual(got, test.want) {
+			if !got.Equal(test.want, false) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
 			}
@@ -1138,7 +1138,7 @@ func TestBodyRemoveAttribute(t *testing.T) {
 			f.Body().RemoveAttribute(test.name)
 			got := f.BuildTokens(nil)
 			format(got)
-			if !reflect.DeepEqual(got, test.want) {
+			if !got.Equal(test.want, false) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
 			}
@@ -1381,7 +1381,7 @@ func TestBodyAppendBlock(t *testing.T) {
 			f.Body().AppendNewBlock(test.blockType, test.labels)
 			got := f.BuildTokens(nil)
 			format(got)
-			if !reflect.DeepEqual(got, test.want) {
+			if !got.Equal(test.want, false) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
 			}

--- a/hclwrite/generate_test.go
+++ b/hclwrite/generate_test.go
@@ -458,7 +458,7 @@ func TestTokensForValue(t *testing.T) {
 		t.Run(test.Val.GoString(), func(t *testing.T) {
 			got := TokensForValue(test.Val)
 
-			if !cmp.Equal(got, test.Want) {
+			if !got.Equal(test.Want, false) {
 				diff := cmp.Diff(got, test.Want, cmp.Comparer(func(a, b []byte) bool {
 					return bytes.Equal(a, b)
 				}))
@@ -501,7 +501,7 @@ func TestTokensForTraversal(t *testing.T) {
 	for _, test := range tests {
 		got := TokensForTraversal(test.Val)
 
-		if !cmp.Equal(got, test.Want) {
+		if !got.Equal(test.Want, false) {
 			diff := cmp.Diff(got, test.Want, cmp.Comparer(func(a, b []byte) bool {
 				return bytes.Equal(a, b)
 			}))

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -2,7 +2,6 @@ package hclwrite
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -1094,7 +1093,7 @@ foo "bar" "baz" {
 		t.Run(test.input, func(t *testing.T) {
 			got := lexConfig([]byte(test.input))
 
-			if !reflect.DeepEqual(got, test.want) {
+			if !got.Equal(test.want, false) {
 				diff := prettyConfig.Compare(test.want, got)
 				t.Errorf(
 					"wrong result\ninput: %s\ndiff:  %s", test.input, diff,

--- a/hclwrite/tokens.go
+++ b/hclwrite/tokens.go
@@ -43,6 +43,22 @@ func (t *Token) asHCLSyntax() hclsyntax.Token {
 // Tokens is a flat list of tokens.
 type Tokens []*Token
 
+// Equal returns whether the token sequence is strictly equal to another series. If ignoreSpaces is set, it will ignore differences in SpacesBefore.
+func (ts Tokens) Equal(tokens Tokens, ignoreSpaces bool) bool {
+	if len(ts) != len(tokens) {
+		return false
+	}
+
+	for i, a := range ts {
+		b := tokens[i]
+		if a.Type != b.Type || (!ignoreSpaces && a.SpacesBefore != b.SpacesBefore) || !bytes.Equal(a.Bytes, b.Bytes) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (ts Tokens) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	ts.WriteTo(buf)

--- a/hclwrite/tokens.go
+++ b/hclwrite/tokens.go
@@ -43,7 +43,7 @@ func (t *Token) asHCLSyntax() hclsyntax.Token {
 // Tokens is a flat list of tokens.
 type Tokens []*Token
 
-// Equal returns whether the token sequence is strictly equal to another series. If ignoreSpaces is set, it will ignore differences in SpacesBefore.
+// Equal returns whether a sequence of tokens is equal to another.
 func (ts Tokens) Equal(tokens Tokens, ignoreSpaces bool) bool {
 	if len(ts) != len(tokens) {
 		return false


### PR DESCRIPTION
This PR adds an `Equal` method that can check if one `tokens` slice is equal to another. I found myself [writing](https://github.com/bendrucker/terraform-cloud-migrate/blob/1a10af5696b831528c73c9dc79ba142fec858c88/variable.go#L172-L185) this method to detect whether a `terraform.workspace` expression was present in any attribute before using `RenameVariablePrefix` (in order to track the files where replacement was needed). 

It can be used in the tests here and might also be useful for tests that users write against their own code that uses hclwrite.