### PR TITLE
Fix a wrong error message for bitwise OR

### DIFF
--- a/hclsyntax/token.go
+++ b/hclsyntax/token.go
@@ -202,7 +202,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 				case TokenBitwiseAnd:
 					suggestion = " Did you mean boolean AND (\"&&\")?"
 				case TokenBitwiseOr:
-					suggestion = " Did you mean boolean OR (\"&&\")?"
+					suggestion = " Did you mean boolean OR (\"||\")?"
 				case TokenBitwiseNot:
 					suggestion = " Did you mean boolean NOT (\"!\")?"
 				}


### PR DESCRIPTION
Fixes #376

before

```
$ echo 'foo = a | b' | go run ./cmd/hclfmt/main.go -check
Error: Unsupported operator

  on <stdin> line 1:
   1: foo = a | b

Bitwise operators are not supported. Did you mean boolean OR ("&&")?

Error: Missing newline after argument

  on <stdin> line 1:
   1: foo = a | b

An argument definition must end with a newline.

one or more files contained errors
exit status 1
```

after

```
$ echo 'foo = a | b' | go run ./cmd/hclfmt/main.go -check
Error: Unsupported operator

  on <stdin> line 1:
   1: foo = a | b

Bitwise operators are not supported. Did you mean boolean OR ("||")?

Error: Missing newline after argument

  on <stdin> line 1:
   1: foo = a | b

An argument definition must end with a newline.

one or more files contained errors
exit status 1
```