### PR TITLE
hclsyntax: Introduce token-based parse methods

### DIFF
--- a/hclsyntax/peeker.go
+++ b/hclsyntax/peeker.go
@@ -112,7 +112,11 @@ func (p *peeker) nextToken() (Token, int) {
 	// if we fall out here then we'll return the EOF token, and leave
 	// our index pointed off the end of the array so we'll keep
 	// returning EOF in future too.
-	return p.Tokens[len(p.Tokens)-1], len(p.Tokens)
+	return p.lastToken(), len(p.Tokens)
+}
+
+func (p *peeker) lastToken() Token {
+	return p.Tokens[len(p.Tokens)-1]
 }
 
 func (p *peeker) includingNewlines() bool {

--- a/hclsyntax/public_test.go
+++ b/hclsyntax/public_test.go
@@ -2,6 +2,10 @@ package hclsyntax
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestValidIdentifier(t *testing.T) {
@@ -43,4 +47,138 @@ func TestValidIdentifier(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseBlockFromTokens_withoutNewline(t *testing.T) {
+	_, diags := ParseBlockFromTokens(testBlockTokensWithoutNewline)
+	if len(diags) != 1 {
+		t.Fatalf("Expected exactly 1 diagnostic, %d given", len(diags))
+	}
+}
+
+func TestParseBlockFromTokens_block(t *testing.T) {
+	b, diags := ParseBlockFromTokens(testBlockTokensWithNewline)
+	if len(diags) > 0 {
+		t.Fatal(diags)
+	}
+	expectedBlock := &Block{
+		Type:   "blocktype",
+		Labels: []string{"onelabel"},
+		Body: &Body{
+			Attributes: Attributes{
+				"attr": &Attribute{
+					Name: "attr",
+					Expr: &LiteralValueExpr{
+						Val: cty.NumberIntVal(42),
+					},
+				},
+			},
+			Blocks: Blocks{},
+		},
+	}
+	opts := cmp.Options{
+		cmpopts.IgnoreUnexported(Body{}),
+		cmpopts.IgnoreUnexported(cty.Value{}),
+	}
+	opts = append(opts, optsIgnoreRanges...)
+	if diff := cmp.Diff(expectedBlock, b, opts); diff != "" {
+		t.Fatalf("Blocks don't match:\n%s", diff)
+	}
+}
+
+func TestParseBlockFromTokens_invalid(t *testing.T) {
+	_, diags := ParseBlockFromTokens(invalidTokens)
+	if len(diags) != 1 {
+		t.Fatalf("Expected exactly 1 diagnostic, %d given", len(diags))
+	}
+}
+
+func TestParseBlockFromTokens_attr(t *testing.T) {
+	_, diags := ParseBlockFromTokens(testAttributeTokensValid)
+	if len(diags) != 1 {
+		t.Fatalf("Expected exactly 1 diagnostic, given:\n%#v", diags)
+	}
+}
+
+func TestParseAttributeFromTokens_attr(t *testing.T) {
+	b, diags := ParseAttributeFromTokens(testAttributeTokensValid)
+	if len(diags) > 0 {
+		t.Fatal(diags)
+	}
+	expectedAttribute := &Attribute{
+		Name: "attr",
+		Expr: &LiteralValueExpr{
+			Val: cty.NumberIntVal(79),
+		},
+	}
+	opts := cmp.Options{
+		cmpopts.IgnoreFields(Token{}, "Range"),
+		cmpopts.IgnoreUnexported(Attribute{}),
+		cmpopts.IgnoreUnexported(cty.Value{}),
+	}
+	if diff := cmp.Diff(expectedAttribute, b, opts); diff != "" {
+		t.Fatalf("Blocks don't match:\n%s", diff)
+	}
+}
+
+func TestParseAttributeFromTokens_invalid(t *testing.T) {
+	_, diags := ParseAttributeFromTokens(invalidTokens)
+	if len(diags) != 1 {
+		t.Fatalf("Expected exactly 1 diagnostic, %d given", len(diags))
+	}
+}
+
+func TestParseAttributeFromTokens_block(t *testing.T) {
+	_, diags := ParseAttributeFromTokens(testBlockTokensWithNewline)
+	if len(diags) != 1 {
+		t.Fatalf("Expected exactly 1 diagnostic, given:\n%#v", diags)
+	}
+}
+
+var optsIgnoreRanges = []cmp.Option{
+	cmpopts.IgnoreFields(Token{}, "Range"),
+	cmpopts.IgnoreFields(Attribute{}, "SrcRange", "NameRange", "EqualsRange"),
+	cmpopts.IgnoreFields(Block{}, "TypeRange", "LabelRanges", "OpenBraceRange", "CloseBraceRange"),
+	cmpopts.IgnoreFields(LiteralValueExpr{}, "SrcRange"),
+	cmpopts.IgnoreFields(Body{}, "SrcRange", "EndRange"),
+}
+
+var testAttributeTokensValid = Tokens{
+	{Type: TokenIdent, Bytes: []byte("attr")},
+	{Type: TokenEqual, Bytes: []byte("=")},
+	{Type: TokenNumberLit, Bytes: []byte("79")},
+	{Type: TokenNewline, Bytes: []byte("\n")},
+}
+
+var testBlockTokensWithNewline = Tokens{
+	{Type: TokenIdent, Bytes: []byte("blocktype")},
+	{Type: TokenOQuote, Bytes: []byte(`"`)},
+	{Type: TokenQuotedLit, Bytes: []byte("onelabel")},
+	{Type: TokenCQuote, Bytes: []byte(`"`)},
+	{Type: TokenOBrace, Bytes: []byte("{")},
+	{Type: TokenNewline, Bytes: []byte("\n")},
+	{Type: TokenIdent, Bytes: []byte("attr")},
+	{Type: TokenEqual, Bytes: []byte("=")},
+	{Type: TokenNumberLit, Bytes: []byte("42")},
+	{Type: TokenNewline, Bytes: []byte("\n")},
+	{Type: TokenCBrace, Bytes: []byte("}")},
+	{Type: TokenNewline, Bytes: []byte("\n")},
+}
+
+var testBlockTokensWithoutNewline = Tokens{
+	{Type: TokenIdent, Bytes: []byte("blocktype")},
+	{Type: TokenOQuote, Bytes: []byte(`"`)},
+	{Type: TokenQuotedLit, Bytes: []byte("onelabel")},
+	{Type: TokenCQuote, Bytes: []byte(`"`)},
+	{Type: TokenOBrace, Bytes: []byte("{")},
+	{Type: TokenNewline, Bytes: []byte("\n")},
+	{Type: TokenIdent, Bytes: []byte("attr")},
+	{Type: TokenEqual, Bytes: []byte("=")},
+	{Type: TokenNumberLit, Bytes: []byte("42")},
+	{Type: TokenNewline, Bytes: []byte("\n")},
+	{Type: TokenCBrace, Bytes: []byte("}")},
+}
+
+var invalidTokens = Tokens{
+	{Type: TokenNewline, Bytes: []byte("\n")},
 }


### PR DESCRIPTION
This change introduces new methods to allow two-phased approach where tokenization is done prior to parsing.

This is specifically useful in the context of a language server, so it can pass around a single interpretation of HCL blocks (tokens) instead of passing around both block and its tokens.

Related: https://github.com/hashicorp/terraform-ls/pull/125

### New methods

```go
func ParseBodyFromTokens(tokens Tokens, end TokenType) (*Body, hcl.Diagnostics)
func ParseBodyItemFromTokens(tokens Tokens) (Node, hcl.Diagnostics)
func ParseBlockFromTokens(tokens Tokens) (*Block, hcl.Diagnostics)
func ParseAttributeFromTokens(tokens Tokens) (*Attribute, hcl.Diagnostics)
```