### PR TITLE
`raise()` function for custom error handling (HCL2)

### DIFF
--- a/ext/tryfunc/README.md
+++ b/ext/tryfunc/README.md
@@ -1,6 +1,6 @@
-# "Try" and "can" functions
+# Error handling function: "try", "can", and "raise"
 
-This Go package contains two `cty` functions intended for use in an
+This Go package contains three `cty` functions intended for use in an
 `hcl.EvalContext` when evaluating HCL native syntax expressions.
 
 The first function `try` attempts to evaluate each of its argument expressions
@@ -17,7 +17,10 @@ The second function `can` is similar except that it ignores the result of
 the given expression altogether and simply returns `true` if the expression
 produced a successful result or `false` if it produced errors.
 
-Both of these are primarily intended for working with deep data structures
+The third function `raise` simply raises a specific custom error message any time it is
+evaluated.
+
+All of these function are primarily intended for working with deep data structures
 which might not have a dependable shape. For example, we can use `try` to
 attempt to fetch a value from deep inside a data structure but produce a
 default value if any step of the traversal fails:
@@ -26,8 +29,9 @@ default value if any step of the traversal fails:
 result = try(foo.deep[0].lots.of["traversals"], null)
 ```
 
-The final result to `try` should generally be some sort of constant value that
-will always evaluate successfully.
+The final result to `try` should generally be (1) some sort of constant value that
+will always evaluate successfully or (2) a call to `raise` that provides a clear error
+message to the user.
 
 ## Using these functions
 
@@ -37,8 +41,9 @@ exporting them in the `hcl.EvalContext` used for expression evaluation:
 ```go
 ctx := &hcl.EvalContext{
     Functions: map[string]function.Function{
-        "try": tryfunc.TryFunc,
         "can": tryfunc.CanFunc,
+        "try": tryfunc.TryFunc,
+        "raise": tryfunc.RaiseFunc,
     },
 }
 ```

--- a/ext/tryfunc/tryfunc.go
+++ b/ext/tryfunc/tryfunc.go
@@ -52,7 +52,7 @@ func init() {
 			Name: "expressions",
 			Type: customdecode.ExpressionClosureType,
 		},
-		Type: function.StaticReturnType(error),
+		Type: function.StaticReturnType(cty.Bool),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			return raise(args[0])
 		},
@@ -119,7 +119,7 @@ func try(args []cty.Value) (cty.Value, error) {
 	return cty.NilVal, errors.New(buf.String())
 }
 
-func raise(arg cty.Value) (cty.NilVal, error) {
+func raise(arg cty.Value) (cty.Value, error) {
 	closure := customdecode.ExpressionClosureFromVal(arg)
 	if dependsOnUnknowns(closure.Expression, closure.EvalContext) {
 		// Can't decide yet, then.
@@ -131,7 +131,7 @@ func raise(arg cty.Value) (cty.NilVal, error) {
 		return cty.NilVal, diags
 	}
 	var buf strings.Builder
-	buf.WriteString(err_msg)
+	buf.WriteString(err_msg.AsString())
 	return cty.NilVal, errors.New(buf.String())
 }
 

--- a/ext/tryfunc/tryfunc.go
+++ b/ext/tryfunc/tryfunc.go
@@ -27,6 +27,9 @@ var TryFunc function.Function
 // CanFunc tries to evaluate the expression given in its first argument.
 var CanFunc function.Function
 
+// RaiseFunc raises its argument's text as a custom error message.
+var RaiseFunc function.Function
+
 func init() {
 	TryFunc = function.New(&function.Spec{
 		VarParam: &function.Parameter{
@@ -42,6 +45,16 @@ func init() {
 		},
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			return try(args)
+		},
+	})
+	RaiseFunc = function.New(&function.Spec{
+		VarParam: &function.Parameter{
+			Name: "expressions",
+			Type: customdecode.ExpressionClosureType,
+		},
+		Type: function.StaticReturnType(error),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			return raise(args[0])
 		},
 	})
 	CanFunc = function.New(&function.Spec{
@@ -103,6 +116,22 @@ func try(args []cty.Value) (cty.Value, error) {
 		}
 	}
 	buf.WriteString("\nAt least one expression must produce a successful result")
+	return cty.NilVal, errors.New(buf.String())
+}
+
+func raise(arg cty.Value) (cty.NilVal, error) {
+	closure := customdecode.ExpressionClosureFromVal(arg)
+	if dependsOnUnknowns(closure.Expression, closure.EvalContext) {
+		// Can't decide yet, then.
+		return cty.UnknownVal(cty.Bool), nil
+	}
+
+	err_msg, diags := closure.Value()
+	if diags.HasErrors() {
+		return cty.NilVal, diags
+	}
+	var buf strings.Builder
+	buf.WriteString(err_msg)
 	return cty.NilVal, errors.New(buf.String())
 }
 

--- a/ext/tryfunc/tryfunc.go
+++ b/ext/tryfunc/tryfunc.go
@@ -48,9 +48,11 @@ func init() {
 		},
 	})
 	RaiseFunc = function.New(&function.Spec{
-		VarParam: &function.Parameter{
-			Name: "expressions",
-			Type: customdecode.ExpressionClosureType,
+		Params: []function.Parameter{
+			{
+				Name: "error_message",
+				Type: customdecode.ExpressionClosureType,
+			},
 		},
 		Type: function.StaticReturnType(cty.Bool),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {

--- a/ext/tryfunc/tryfunc_test.go
+++ b/ext/tryfunc/tryfunc_test.go
@@ -138,9 +138,9 @@ func TestRaiseFunc(t *testing.T) {
 		"custom error raised": {
 			`raise(foo)`,
 			map[string]cty.Value{
-				"foo": "foo",
+				"foo": cty.StringVal("foo"),
 			},
-			nil,
+			cty.NilVal,
 			`foo`,
 		},
 		"no arguments": {

--- a/ext/tryfunc/tryfunc_test.go
+++ b/ext/tryfunc/tryfunc_test.go
@@ -147,7 +147,7 @@ func TestRaiseFunc(t *testing.T) {
 			`raise()`,
 			nil,
 			cty.NilVal,
-			`test.hcl:1,1-7: Error in function call; Call to function "raise" failed: exactly one argument is required.`,
+			`test.hcl:1,7-8: Not enough function arguments; Function "raise" expects 1 argument(s). Missing value for "error_message".`,
 		},
 	}
 

--- a/ext/tryfunc/tryfunc_test.go
+++ b/ext/tryfunc/tryfunc_test.go
@@ -141,7 +141,7 @@ func TestRaiseFunc(t *testing.T) {
 				"foo": cty.StringVal("foo"),
 			},
 			cty.NilVal,
-			`foo`,
+			`test.hcl:1,1-7: Error in function call; Call to function "raise" failed: foo.`,
 		},
 		"no arguments": {
 			`raise()`,


### PR DESCRIPTION
**UPDATE: CI Tests are now passing, PR is ready for review and feedback.**

This is my first contribution to Terraform and HCL. Comments, suggestions, and guidance are all welcome.

Essentially, this update adds a new `raise` function which Terraform developers can leverage to improve error handling and messaging to users.

Usage:

```hcl
locals {
  progress = 50
  of_total_a = 0
  of_total_b = null
  of_total_c = 100
}
locals {
  #raises a custom error using if/then/else syntax:
  my_value = local.of_total_a = null ? raise("invalid denominator") : local.progress / local.of_total_a

  #raises a custom error using try():
  my_value = try(local.progress / local.of_total_a, raise("invalid denominator"))

  #raises a custom error using coalesce() if value is null:
  my_value = local.progress / coalesce(local.of_total_b, raise("denominator is null"))

  # succeeds (no error)
  my_value = try(local.progress / local.of_total_c, raise("(will not be reached)"))
}
```

NOTE: This change also requires a change to the Terraform repo, tracked here: https://github.com/hashicorp/terraform/pull/25088

Resolves https://github.com/hashicorp/terraform/issues/24269
