### PR TITLE
hclsyntax: ConditionalExpr unification fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sergi/go-diff v1.0.0
 	github.com/spf13/pflag v1.0.2
 	github.com/stretchr/testify v1.2.2 // indirect
-	github.com/zclconf/go-cty v1.2.0
+	github.com/zclconf/go-cty v1.4.2
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/zclconf/go-cty v1.2.0 h1:sPHsy7ADcIZQP3vILvTjrh74ZA175TFP5vqiNK1UmlI=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
+github.com/zclconf/go-cty v1.4.2 h1:GKcsRGjxZnRRlyVk2Y6PyG3fdcn3Pv0D7KT4xyYTLlE=
+github.com/zclconf/go-cty v1.4.2/go.mod h1:nHzOclRkoj++EU9ZjSrZvRG0BXIWt8c7loYc0qXAFGQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1516,6 +1516,92 @@ EOT
 			cty.DynamicVal,
 			0,
 		},
+		{
+			`true ? ["a", "b"]: []`,
+			nil,
+			cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			0,
+		},
+		{
+			`false ? ["a", "b"]: []`,
+			nil,
+			cty.ListValEmpty(cty.String),
+			0,
+		},
+		{
+			`true ? { a = true, b = "two" }: {}`,
+			nil,
+			cty.MapVal(map[string]cty.Value{"a": cty.StringVal("true"), "b": cty.StringVal("two")}),
+			0,
+		},
+		{
+			`false ? { a = true, b = "two" }: {}`,
+			nil,
+			cty.MapValEmpty(cty.String),
+			0,
+		},
+		{
+			`true ? { a = [1], b = "two" }: {}`,
+			nil,
+			cty.ObjectVal(map[string]cty.Value{"a": cty.TupleVal([]cty.Value{cty.NumberIntVal(1)}), "b": cty.StringVal("two")}),
+			0,
+		},
+		{
+			`false ? { a = [1], b = "two" }: {}`,
+			nil,
+			cty.EmptyObjectVal,
+			0,
+		},
+		{
+			`merge({ a = [1], b = [2] }, cond ? { b = "two", c = [3] } : { c = "three" })`,
+			&hcl.EvalContext{
+				Functions: map[string]function.Function{
+					"merge": stdlib.MergeFunc,
+				},
+				Variables: map[string]cty.Value{
+					"cond": cty.True,
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.TupleVal([]cty.Value{cty.NumberIntVal(1)}),
+				"b": cty.StringVal("two"),
+				"c": cty.TupleVal([]cty.Value{cty.NumberIntVal(3)}),
+			}),
+			0,
+		},
+		{
+			`merge({ a = [1], b = [2] }, cond ? { b = "two", c = [3] } : { c = "three" })`,
+			&hcl.EvalContext{
+				Functions: map[string]function.Function{
+					"merge": stdlib.MergeFunc,
+				},
+				Variables: map[string]cty.Value{
+					"cond": cty.False,
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.TupleVal([]cty.Value{cty.NumberIntVal(1)}),
+				"b": cty.TupleVal([]cty.Value{cty.NumberIntVal(2)}),
+				"c": cty.StringVal("three"),
+			}),
+			0,
+		},
+		{
+			`merge({ a = [1], b = [2] }, cond ? { b = "two", c = [3] } : {})`,
+			&hcl.EvalContext{
+				Functions: map[string]function.Function{
+					"merge": stdlib.MergeFunc,
+				},
+				Variables: map[string]cty.Value{
+					"cond": cty.False,
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.TupleVal([]cty.Value{cty.NumberIntVal(1)}),
+				"b": cty.TupleVal([]cty.Value{cty.NumberIntVal(2)}),
+			}),
+			0,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
If we are unable to unify the two sides of a conditional expression, this should not result in an error. Instead we should return the unconverted value, and if this causes an error higher up in the evaluation, it can be handled there.

### Motivation

The motivation for this is to allow disjoint conditional expression values to be evaluated, where the context of the expression permits this. For example, the `merge` function can combine any object types, and we should be able to use conditional expressions as arguments to this function. [See this downstream Terraform issue for more real world examples](https://github.com/hashicorp/terraform/issues/22405).

This commit also updates the go-cty dependency in order to bring in the `merge` function for a test case of the new behaviour.
