### PR TITLE
hclsyntax: address multiple issues with sequences (...)

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -260,6 +260,8 @@ func (e *FunctionCallExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnosti
 		}
 
 		switch {
+		case expandVal.Type().Equals(cty.DynamicPseudoType):
+			return cty.DynamicVal, diags
 		case expandVal.Type().IsTupleType() || expandVal.Type().IsListType() || expandVal.Type().IsSetType():
 			if expandVal.IsNull() {
 				diags = append(diags, &hcl.Diagnostic{

--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -261,6 +261,18 @@ func (e *FunctionCallExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnosti
 
 		switch {
 		case expandVal.Type().Equals(cty.DynamicPseudoType):
+			if expandVal.IsNull() {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity:    hcl.DiagError,
+					Summary:     "Invalid expanding argument value",
+					Detail:      "The expanding argument (indicated by ...) must not be null.",
+					Subject:     expandExpr.Range().Ptr(),
+					Context:     e.Range().Ptr(),
+					Expression:  expandExpr,
+					EvalContext: ctx,
+				})
+				return cty.DynamicVal, diags
+			}
 			return cty.DynamicVal, diags
 		case expandVal.Type().IsTupleType() || expandVal.Type().IsListType() || expandVal.Type().IsSetType():
 			if expandVal.IsNull() {

--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -406,22 +406,39 @@ func (e *FunctionCallExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnosti
 			} else {
 				param = varParam
 			}
-			argExpr := e.Args[i]
 
-			// TODO: we should also unpick a PathError here and show the
-			// path to the deep value where the error was detected.
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid function argument",
-				Detail: fmt.Sprintf(
-					"Invalid value for %q parameter: %s.",
-					param.Name, err,
-				),
-				Subject:     argExpr.StartRange().Ptr(),
-				Context:     e.Range().Ptr(),
-				Expression:  argExpr,
-				EvalContext: ctx,
-			})
+			// this can happen if an argument is (incorrectly) null.
+			if i > len(e.Args)-1 {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid function argument",
+					Detail: fmt.Sprintf(
+						"Invalid value for %q parameter: %s.",
+						param.Name, err,
+					),
+					Subject:     args[len(params)].StartRange().Ptr(),
+					Context:     e.Range().Ptr(),
+					Expression:  e,
+					EvalContext: ctx,
+				})
+			} else {
+				argExpr := e.Args[i]
+
+				// TODO: we should also unpick a PathError here and show the
+				// path to the deep value where the error was detected.
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid function argument",
+					Detail: fmt.Sprintf(
+						"Invalid value for %q parameter: %s.",
+						param.Name, err,
+					),
+					Subject:     argExpr.StartRange().Ptr(),
+					Context:     e.Range().Ptr(),
+					Expression:  argExpr,
+					EvalContext: ctx,
+				})
+			}
 
 		default:
 			diags = append(diags, &hcl.Diagnostic{

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -313,6 +313,16 @@ upper(
 			1, // too many function arguments
 		},
 		{
+			`concat([1, null]...)`,
+			&hcl.EvalContext{
+				Functions: map[string]function.Function{
+					"concat": stdlib.ConcatFunc,
+				},
+			},
+			cty.DynamicVal,
+			1, // argument cannot be null
+		},
+		{
 			`[]`,
 			nil,
 			cty.EmptyTupleVal,

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -323,6 +323,21 @@ upper(
 			1, // argument cannot be null
 		},
 		{
+			`concat(var.unknownlist...)`,
+			&hcl.EvalContext{
+				Functions: map[string]function.Function{
+					"concat": stdlib.ConcatFunc,
+				},
+				Variables: map[string]cty.Value{
+					"var": cty.ObjectVal(map[string]cty.Value{
+						"unknownlist": cty.UnknownVal(cty.DynamicPseudoType),
+					}),
+				},
+			},
+			cty.DynamicVal,
+			0,
+		},
+		{
 			`[]`,
 			nil,
 			cty.EmptyTupleVal,


### PR DESCRIPTION
Update: I ended up tackling two adjacent bugs at once. 

-----

Previously functions such as `concat()` would result in a panic if there
was a null element and a sequence, as in the included test. This PR adds
a check if the error index is outside of the range of arguments and
crafts an error that references the entire function instead of the null
argument.

Tested locally to confirm that this fixes a reported terraform panic:
<img width="709" alt="Screen Shot 2020-06-03 at 9 13 08 AM" src="https://user-images.githubusercontent.com/6210214/83641030-f39d8000-a57a-11ea-9963-389de2d28c92.png">
