### PR TITLE
json: Add json.ParseWithStartPos function

### DIFF
--- a/json/parser.go
+++ b/json/parser.go
@@ -8,15 +8,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func parseFileContent(buf []byte, filename string) (node, hcl.Diagnostics) {
-	tokens := scan(buf, pos{
-		Filename: filename,
-		Pos: hcl.Pos{
-			Byte:   0,
-			Line:   1,
-			Column: 1,
-		},
-	})
+func parseFileContent(buf []byte, filename string, start hcl.Pos) (node, hcl.Diagnostics) {
+	tokens := scan(buf, pos{Filename: filename, Pos: start})
 	p := newPeeker(tokens)
 	node, diags := parseValue(p)
 	if len(diags) == 0 && p.Peek().Type != tokenEOF {

--- a/json/public.go
+++ b/json/public.go
@@ -18,7 +18,16 @@ import (
 // from its HasErrors method. If HasErrors returns true, the file represents
 // the subset of data that was able to be parsed, which may be none.
 func Parse(src []byte, filename string) (*hcl.File, hcl.Diagnostics) {
-	rootNode, diags := parseFileContent(src, filename)
+	return ParseWithStartPos(src, filename, hcl.Pos{Byte: 0, Line: 1, Column: 1})
+}
+
+// ParseWithStartPos attempts to parse like json.Parse, but unlike json.Parse
+// you can pass a start position of the given JSON as a hcl.Pos.
+//
+// In most cases json.Parse should be sufficient, but it can be useful for parsing
+// a part of JSON with correct positions.
+func ParseWithStartPos(src []byte, filename string, start hcl.Pos) (*hcl.File, hcl.Diagnostics) {
+	rootNode, diags := parseFileContent(src, filename, start)
 
 	switch rootNode.(type) {
 	case *objectVal, *arrayVal:


### PR DESCRIPTION
Similar to `hclsyntax.ParseConfig`, this PR changes the start position to be passed to the `json.Parse` function.

This feature is necessary to transfer `hcl.Block` via RPC. We need to be able to specify the start position when we take a partial JSON and parse it on the other side. See also #332 #381 

However, I understand that this change breaks backward compatibility. I propose this change for interface consistency, but if you care about compatibility, I could add a parsing function that accepts positions (e.g. `json.ParseWithPos`). Please tell me your opinion.