### PR TITLE
hclwrite: Add block label quoting to format

### DIFF
--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -608,12 +608,32 @@ module "x" {
   abcde = "456"
 }`,
 		},
+		{
+			`
+module foo {
+source="./modules/foo"
+}
+
+resource null_resource nowt {}
+
+resource null_resource "nada"{
+}`,
+			`
+module "foo" {
+  source = "./modules/foo"
+}
+
+resource "null_resource" "nowt" {}
+
+resource "null_resource" "nada" {
+}`,
+		},
 	}
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
 			tokens := lexConfig([]byte(test.input))
-			format(tokens)
+			tokens = format(tokens)
 			t.Logf("tokens %s\n", spew.Sdump(tokens))
 			got := string(tokens.Bytes())
 

--- a/hclwrite/public.go
+++ b/hclwrite/public.go
@@ -37,7 +37,7 @@ func ParseConfig(src []byte, filename string, start hcl.Pos) (*File, hcl.Diagnos
 // desirable.
 func Format(src []byte) []byte {
 	tokens := lexConfig(src)
-	format(tokens)
+	tokens = format(tokens)
 	buf := &bytes.Buffer{}
 	tokens.WriteTo(buf)
 	return buf.Bytes()


### PR DESCRIPTION
Blocks consist of an identifier, followed by zero or more labels, and a body. Each label can be either an identifier or a quoted string literal.

This commit updates `hclwrite`'s format logic to replace any identifier labels with quoted strings. That is, for this input:

```hcl
resource null_resource test { }
```

`hclwrite` will prduce the following output:

```hcl
resource "null_resource" "test" { }
```