### PR TITLE
hclwrite: do not add space after a bang

### DIFF
--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -263,6 +263,10 @@ func spaceAfterToken(subject, before, after *Token) bool {
 	case after.Type == hclsyntax.TokenOBrack && (subject.Type == hclsyntax.TokenIdent || subject.Type == hclsyntax.TokenNumberLit || tokenBracketChange(subject) < 0):
 		return false
 
+	case subject.Type == hclsyntax.TokenBang:
+		// No space after a bang
+		return false
+
 	case subject.Type == hclsyntax.TokenMinus:
 		// Since a minus can either be subtraction or negation, and the latter
 		// should _not_ have a space after it, we need to use some heuristics

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -68,6 +68,10 @@ func TestFormat(t *testing.T) {
 			`foo(a, b...)`,
 		},
 		{
+			`! true`,
+			`!true`,
+		},
+		{
 			`a="hello ${ name }"`,
 			`a = "hello ${name}"`,
 		},


### PR DESCRIPTION
A space should not be added after a bang (`!`) - which is used for negation.

See: https://www.terraform.io/docs/configuration/expressions.html#logical-operators