### PR TITLE
Fix panic traversing marked map

### DIFF
--- a/hclsyntax/expression_template_test.go
+++ b/hclsyntax/expression_template_test.go
@@ -287,7 +287,7 @@ trim`,
 			`hello%{ if false } ${target}%{ endif }`,
 			&hcl.EvalContext{
 				Variables: map[string]cty.Value{
-					"target": cty.StringVal("world").WithMarks(cty.NewValueMarks("sensitive")),
+					"target": cty.StringVal("world").Mark("sensitive"),
 				},
 			},
 			cty.StringVal("hello"),
@@ -297,11 +297,23 @@ trim`,
 			`${greeting} ${target}`,
 			&hcl.EvalContext{
 				Variables: map[string]cty.Value{
-					"greeting": cty.StringVal("hello").WithMarks(cty.NewValueMarks("english")),
-					"target":   cty.StringVal("world").WithMarks(cty.NewValueMarks("sensitive")),
+					"greeting": cty.StringVal("hello").Mark("english"),
+					"target":   cty.StringVal("world").Mark("sensitive"),
 				},
 			},
 			cty.StringVal("hello world").WithMarks(cty.NewValueMarks("english", "sensitive")),
+			0,
+		},
+		{ // can use marks by traversing complex values
+			`Authenticate with "${secrets.passphrase}"`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"secrets": cty.MapVal(map[string]cty.Value{
+						"passphrase": cty.StringVal("my voice is my passport").Mark("sensitive"),
+					}).Mark("sensitive"),
+				},
+			},
+			cty.StringVal(`Authenticate with "my voice is my passport"`).WithMarks(cty.NewValueMarks("sensitive")),
 			0,
 		},
 	}

--- a/ops.go
+++ b/ops.go
@@ -217,7 +217,12 @@ func GetAttr(obj cty.Value, attrName string, srcRange *Range) (cty.Value, Diagno
 		}
 
 		idx := cty.StringVal(attrName)
-		if obj.HasIndex(idx).False() {
+
+		// Here we drop marks from HasIndex result, in order to allow basic
+		// traversal of a marked map in the same way we can traverse a marked
+		// object
+		hasIndex, _ := obj.HasIndex(idx).Unmark()
+		if hasIndex.False() {
 			return cty.DynamicVal, Diagnostics{
 				{
 					Severity: DiagError,

--- a/ops_test.go
+++ b/ops_test.go
@@ -49,6 +49,15 @@ func TestApplyPath(t *testing.T) {
 			``,
 		},
 		{
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("foo").Mark("x"),
+				"b": cty.StringVal("bar").Mark("x"),
+			}).Mark("x"),
+			cty.GetAttrPath("a"),
+			cty.StringVal("foo").Mark("x"),
+			``,
+		},
+		{
 			cty.ListValEmpty(cty.String),
 			(cty.Path)(nil).Index(cty.NumberIntVal(0)),
 			cty.NilVal,


### PR DESCRIPTION
If a `cty.Map` was marked, traversing it by path would previously panic. From the existing code, this may have been by design, but it does make it particularly difficult to use marks with Terraform values. This commit fixes the panic by explicitly dropping marks when checking if a map has a given attribute.

PR includes a new test of traversing a marked map to demonstrate the use case for this.

@apparentlymart, I'm concerned that this may be against the goals of how marks are supposed to be used, but I can't see any reasonable alternative here. What do you think?