### PR TITLE
hclsyntax: Fix for expressions over marked values

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -971,6 +971,9 @@ func (e *ForExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	if collVal.Type() == cty.DynamicPseudoType {
 		return cty.DynamicVal, diags
 	}
+	// Unmark collection before checking for iterability, because marked
+	// values cannot be iterated
+	collVal, marks := collVal.Unmark()
 	if !collVal.CanIterateElements() {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
@@ -1178,7 +1181,7 @@ func (e *ForExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 			}
 		}
 
-		return cty.ObjectVal(vals), diags
+		return cty.ObjectVal(vals).WithMarks(marks), diags
 
 	} else {
 		// Producing a tuple
@@ -1254,7 +1257,7 @@ func (e *ForExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 			return cty.DynamicVal, diags
 		}
 
-		return cty.TupleVal(vals), diags
+		return cty.TupleVal(vals).WithMarks(marks), diags
 	}
 }
 

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -854,6 +854,41 @@ upper(
 			}),
 			0,
 		},
+		{ // Marked sequence results in a marked tuple
+			`[for x in things: x if x != ""]`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.ListVal([]cty.Value{
+						cty.StringVal("a"),
+						cty.StringVal("b"),
+						cty.StringVal(""),
+						cty.StringVal("c"),
+					}).Mark("sensitive"),
+				},
+			},
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("b"),
+				cty.StringVal("c"),
+			}).Mark("sensitive"),
+			0,
+		},
+		{ // Marked map results in a marked object
+			`{for k, v in things: k => !v}`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.MapVal(map[string]cty.Value{
+						"a": cty.True,
+						"b": cty.False,
+					}).Mark("sensitive"),
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.False,
+				"b": cty.True,
+			}).Mark("sensitive"),
+			0,
+		},
 
 		{
 			`[{name: "Steve"}, {name: "Ermintrude"}].*.name`,


### PR DESCRIPTION
A for expression over a marked collection should result in a new collection with the same marks. Previously this would fail with a type error.