### PR TITLE
Bugfix: #402 new line token added before closing parenthesis on expre…

### DIFF
--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -278,10 +278,10 @@ func parseAttribute(nativeAttr *hclsyntax.Attribute, from, leadComments, lineCom
 		children.AppendNode(cn)
 	}
 
-	children.AppendUnstructuredTokens(newline.Tokens())
-
 	// Collect any stragglers, though there shouldn't be any
 	children.AppendUnstructuredTokens(from.Tokens())
+
+	children.AppendUnstructuredTokens(newline.Tokens())
 
 	return newNode(attr)
 }


### PR DESCRIPTION
…ssion lines

Reproducing example:
the following snippet, the newline will preceed the closing parethesis,
rewriting the parsed hcl will place it in the same line as `strategy`:

```
resource "kubernetes_deployment" "k" {
  spec {
    replicas = true ? 0 : (false ? 1 : 2)
    strategy {
      type = "whatever"
    }
  }
}
```

resolves https://github.com/env0/terratag/pull/63#issue-501335342