### PR TITLE
Return an undefined Pos for an empty ObjectList

### DIFF
--- a/hcl/ast/ast.go
+++ b/hcl/ast/ast.go
@@ -112,7 +112,7 @@ func (o *ObjectList) Elem() *ObjectList {
 func (o *ObjectList) Pos() token.Pos {
 	// If an Object has no members, it won't have a first item
 	// to use as position
-	if len(o.Items)==0 {
+	if len(o.Items) == 0 {
 		return unknownPos
 	}
 	// Return the uninitialized position

--- a/hcl/ast/ast.go
+++ b/hcl/ast/ast.go
@@ -25,6 +25,8 @@ func (ObjectType) node()   {}
 func (LiteralType) node()  {}
 func (ListType) node()     {}
 
+var unknownPos token.Pos
+
 // File represents a single HCL file
 type File struct {
 	Node     Node            // usually a *ObjectList
@@ -108,7 +110,12 @@ func (o *ObjectList) Elem() *ObjectList {
 }
 
 func (o *ObjectList) Pos() token.Pos {
-	// always returns the uninitiliazed position
+	// If an Object has no members, it won't have a first item
+	// to use as position
+	if len(o.Items)==0 {
+		return unknownPos
+	}
+	// Return the uninitialized position
 	return o.Items[0].Pos()
 }
 
@@ -133,10 +140,10 @@ type ObjectItem struct {
 }
 
 func (o *ObjectItem) Pos() token.Pos {
-	// I'm not entirely sure what causes this, but removing this causes
-	// a test failure. We should investigate at some point.
+	// If a parsed object has no keys, there is no position
+	// for its first element.
 	if len(o.Keys) == 0 {
-		return token.Pos{}
+		return unknownPos
 	}
 
 	return o.Keys[0].Pos()


### PR DESCRIPTION
When decoding a value which contains an object (with braces) but no content, there is no first Item to use for the position in errors.  Instead return an undefined tokenPos.