### PR TITLE
Support unknown variable evaluation

### DIFF
--- a/eval_context.go
+++ b/eval_context.go
@@ -11,6 +11,10 @@ type EvalContext struct {
 	Variables map[string]cty.Value
 	Functions map[string]function.Function
 	parent    *EvalContext
+
+	// UnknownVariable handles when an unknown variable is referenced.
+	// This handler is experimental and may change in the future.
+	UnknownVariable func(Traversal) (cty.Value, error)
 }
 
 // NewChild returns a new EvalContext that is a child of the receiver.


### PR DESCRIPTION
Expose a callback to handle unknown variables found in hcl syntax. This is useful in situations where the variables aren't known statically upfront.

When a chain of EvalContexts is used, the deepest child context with set UnknownVariable is used.