### PR TITLE
Allow decoding labels to pointers

### DIFF
--- a/gohcl/decode.go
+++ b/gohcl/decode.go
@@ -264,7 +264,12 @@ func decodeBlockToValue(block *hcl.Block, ctx *hcl.EvalContext, v reflect.Value)
 			blockTags := getFieldTags(ty)
 			for li, lv := range block.Labels {
 				lfieldIdx := blockTags.Labels[li].FieldIndex
-				v.Field(lfieldIdx).Set(reflect.ValueOf(lv))
+				f := v.Field(lfieldIdx)
+				if f.Kind() == reflect.Ptr {
+					f.Set(reflect.ValueOf(&lv))
+				} else {
+					f.SetString(lv)
+				}
 			}
 		}
 

--- a/gohcl/decode_test.go
+++ b/gohcl/decode_test.go
@@ -401,6 +401,27 @@ func TestDecodeBody(t *testing.T) {
 		{
 			map[string]interface{}{
 				"noodle": map[string]interface{}{
+					"sample_label": map[string]interface{}{},
+				},
+			},
+			makeInstantiateType(struct {
+				Noodle struct {
+					Name *string `hcl:"name,label"`
+				} `hcl:"noodle,block"`
+			}{}),
+			func(gotI interface{}) bool {
+				noodle := gotI.(struct {
+					Noodle struct {
+						Name *string `hcl:"name,label"`
+					} `hcl:"noodle,block"`
+				}).Noodle
+				return noodle.Name != nil && *noodle.Name == "sample_label"
+			},
+			0,
+		},
+		{
+			map[string]interface{}{
+				"noodle": map[string]interface{}{
 					"foo_foo": map[string]interface{}{},
 				},
 			},


### PR DESCRIPTION
Supporting having the label field to be a pointer (e.g. `*string`).