### PR TITLE
Decode blocks into map with custom struct types

### DIFF
--- a/gohcl/decode_test.go
+++ b/gohcl/decode_test.go
@@ -486,6 +486,68 @@ func TestDecodeBody(t *testing.T) {
 		{
 			map[string]interface{}{
 				"noodle": map[string]interface{}{
+					"foo_foo": map[string]interface{}{},
+					"bar_baz": map[string]interface{}{},
+				},
+			},
+			makeInstantiateType(struct {
+				Noodles map[string]struct {
+					Name string `hcl:"name,label"`
+				} `hcl:"noodle,block"`
+			}{}),
+			func(gotI interface{}) bool {
+				noodles := gotI.(struct {
+					Noodles map[string]struct {
+						Name string `hcl:"name,label"`
+					} `hcl:"noodle,block"`
+				}).Noodles
+				if len(noodles) != 2 {
+					return false
+				}
+				if _, ok := noodles["foo_foo"]; !ok {
+					return false
+				}
+				if _, ok := noodles["bar_baz"]; !ok {
+					return false
+				}
+				return true
+			},
+			0,
+		},
+		{
+			map[string]interface{}{
+				"noodle": map[string]interface{}{
+					"foo_foo": map[string]interface{}{},
+					"bar_baz": map[string]interface{}{},
+				},
+			},
+			makeInstantiateType(struct {
+				Noodles map[string]*struct {
+					Name string `hcl:"name,label"`
+				} `hcl:"noodle,block"`
+			}{}),
+			func(gotI interface{}) bool {
+				noodles := gotI.(struct {
+					Noodles map[string]*struct {
+						Name string `hcl:"name,label"`
+					} `hcl:"noodle,block"`
+				}).Noodles
+				if len(noodles) != 2 {
+					return false
+				}
+				if _, ok := noodles["foo_foo"]; !ok {
+					return false
+				}
+				if _, ok := noodles["bar_baz"]; !ok {
+					return false
+				}
+				return true
+			},
+			0,
+		},
+		{
+			map[string]interface{}{
+				"noodle": map[string]interface{}{
 					"foo_foo": map[string]interface{}{
 						"type": "rice",
 					},


### PR DESCRIPTION
HCLv2 gohcl supports parsing labeled blocks into slices (e.g. `[]customStruct`).  This adds support for decoding labeled blocks into map types (e.g. `map[string]customStruct`), with the additional constraint that labels are unique.

We special case single labeled blocks, as the behavior for multi labeled blocks is not well scoped.

This i s motivated by some map typed fields in Nomad structure (like [`TaskGroup.Volumes`](https://github.com/hashicorp/nomad/blob/9e9dac4a2c94deffaf3857d8080b947f112c9b11/api/tasks.go#L420), and [`ConsulGatewayProxy. EnvoyGatewayBindAddresses`](https://github.com/hashicorp/nomad/blob/9e9dac4a2c94deffaf3857d8080b947f112c9b11/api/services.go#L347). While I suspect this is of wider benefit, I understand if the use case is deemed to narrow to include into the base gohcl library.

Concretely, assuming a type `Policies  map[string]customStruct 'hcl:"policy,block"'`, the following hcl declaration

```hcl
policy "foo" {
  val = "a"
}
policy "bar" {
  val = "b"
}
```

is decoded as

```go
map[string}*customStruct{
  "foo": &customStruct{Val: "a"},
  "bar": &customStruct{Val: "b"},
}
```

