### PR TITLE
Fix the logic for `null[*]`

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1320,12 +1320,6 @@ func (e *SplatExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	}
 
 	sourceTy := sourceVal.Type()
-	if sourceTy == cty.DynamicPseudoType {
-		// If we don't even know the _type_ of our source value yet then
-		// we'll need to defer all processing, since we can't decide our
-		// result type either.
-		return cty.DynamicVal, diags
-	}
 
 	// A "special power" of splat expressions is that they can be applied
 	// both to tuples/lists and to other values, and in the latter case
@@ -1346,6 +1340,13 @@ func (e *SplatExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 			Expression:  e.Source,
 			EvalContext: ctx,
 		})
+		return cty.DynamicVal, diags
+	}
+
+	if sourceTy == cty.DynamicPseudoType {
+		// If we don't even know the _type_ of our source value yet then
+		// we'll need to defer all processing, since we can't decide our
+		// result type either.
 		return cty.DynamicVal, diags
 	}
 

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -908,6 +908,12 @@ upper(
 			0,
 		},
 		{
+			`null[*]`,
+			nil,
+			cty.EmptyTupleVal,
+			0,
+		},
+		{
 			`{name: "Steve"}[*].name`,
 			nil,
 			cty.TupleVal([]cty.Value{


### PR DESCRIPTION
According to https://discuss.hashicorp.com/t/pattern-to-handle-optional-dynamic-blocks/2384/2
`null[*]` is defined and should return an empty tuple. The logic in
SplatExpr.Value() is slightly wrong thought as it returns early with a
dynamic value even when the value is actually known to be null.

The fix is easy, just check for null sources first, then for dynamic
values. I added a test for this in TestExpressionParseAndValue().