### PR TITLE
hclwrite: Allow blank quoted string block labels

### DIFF
--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -159,6 +159,12 @@ func (bl *blockLabels) Current() []string {
 				if !diags.HasErrors() {
 					labelNames = append(labelNames, labelString)
 				}
+			} else if len(tokens) == 2 &&
+				tokens[0].Type == hclsyntax.TokenOQuote &&
+				tokens[1].Type == hclsyntax.TokenCQuote {
+				// An open quote followed immediately by a closing quote is a
+				// valid but unusual blank string label.
+				labelNames = append(labelNames, "")
 			}
 
 		default:

--- a/hclwrite/ast_block_test.go
+++ b/hclwrite/ast_block_test.go
@@ -107,6 +107,13 @@ escape "\u0041" {
 `,
 			[]string{"\u0041"},
 		},
+		{
+			`
+blank "" {
+}
+`,
+			[]string{""},
+		},
 	}
 
 	for _, test := range tests {
@@ -414,7 +421,7 @@ func TestBlockSetLabels(t *testing.T) {
 		{
 			`foo "hoge" /* foo */  "" {}`,
 			"foo",
-			[]string{"hoge"},
+			[]string{"hoge", ""},
 			[]string{"fuga"}, // force quoted form even if the old one is unquoted.
 			Tokens{
 				{


### PR DESCRIPTION
The `hclsyntax` package permits block labels to be blank quoted strings, and defers to the application to determine if this is valid or not. This commit updates `hclwrite` to allow the same behaviour.

This is in response to [an upstream bug report on Terraform](https://github.com/hashicorp/terraform/issues/26960), which uses `hclwrite` to implement its `fmt` subcommand. Given a block with a blank quoted string label, it currently deletes the label when formatting. This is inconsistent with Terraform's behaviour when parsing HCL, which treats empty labels differently from missing labels:

```hcl
provider "" {}

provider {}
```

```shellsession
$ terraform init
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Invalid provider local name

  on main.tf line 1:
   1: provider "" {}

 is an invalid provider local name: must have at least one character


Error: Missing name for provider

  on main.tf line 3, in provider:
   3: provider {}

All provider blocks must have 1 labels (name).
```

I've confirmed that incorporating this change into Terraform fixes the upstream bug.