### PR TITLE
Fix panic traversing marked list

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -76,7 +76,10 @@ func Index(collection, key cty.Value, srcRange *Range) (cty.Value, Diagnostics) 
 			}
 		}
 
-		has := collection.HasIndex(key)
+		// Here we drop marks from HasIndex result, in order to allow basic
+		// traversal of a marked list, tuple, or map in the same way we can
+		// traverse a marked object
+		has, _ := collection.HasIndex(key).Unmark()
 		if !has.IsKnown() {
 			if ty.IsTupleType() {
 				return cty.DynamicVal, nil

--- a/ops_test.go
+++ b/ops_test.go
@@ -41,6 +41,14 @@ func TestApplyPath(t *testing.T) {
 			``,
 		},
 		{
+			cty.ListVal([]cty.Value{
+				cty.StringVal("hello"),
+			}).Mark("x"),
+			(cty.Path)(nil).Index(cty.NumberIntVal(0)),
+			cty.StringVal("hello").Mark("x"),
+			``,
+		},
+		{
 			cty.TupleVal([]cty.Value{
 				cty.StringVal("hello"),
 			}),


### PR DESCRIPTION
We need to unmark the result of `HasIndex` in order to compare it with true or false without a panic.

Basically the same fix as #406. Downstream bug in Terraform `sensitive` values: https://github.com/hashicorp/terraform/issues/27041