### PR TITLE
allow interface/[]interface types to be encoded if interface is struct type

### DIFF
--- a/gohcl/encode.go
+++ b/gohcl/encode.go
@@ -145,13 +145,26 @@ func populateBody(rv reflect.Value, ty reflect.Type, tags *fieldTags, dst *hclwr
 		} else { // must be a block, then
 			elemTy := fieldTy
 			isSeq := false
-			if elemTy.Kind() == reflect.Slice || elemTy.Kind() == reflect.Array {
+
+			switch elemTy.Kind() {
+			case reflect.Slice, reflect.Array:
 				isSeq = true
 				elemTy = elemTy.Elem()
-			}
 
-			if bodyType.AssignableTo(elemTy) || attrsType.AssignableTo(elemTy) {
-				continue // ignore undecoded fields
+				if bodyType.AssignableTo(elemTy) || attrsType.AssignableTo(elemTy) {
+					// allow every value in the slice/array to be checked separately in case
+					// the field has type `[]interface{}` or `[n]interface{}`
+					if elemTy.Kind() != reflect.Interface {
+						continue
+					}
+				}
+			default:
+				if bodyType.AssignableTo(elemTy) || attrsType.AssignableTo(elemTy) {
+					// allow struct types to be passed as an interface{}
+					if !(elemTy.Kind() == reflect.Interface && fieldVal.Elem().Kind() == reflect.Struct) {
+						continue // ignore undecoded fields
+					}
+				}
 			}
 			prevWasBlock = false
 

--- a/gohcl/encode_test.go
+++ b/gohcl/encode_test.go
@@ -8,6 +8,26 @@ import (
 )
 
 func ExampleEncodeIntoBody() {
+	type DynamicExample struct {
+		Foo string  `hcl:"foo"`
+		Bar float64 `hcl:"bar"`
+		Baz bool    `hcl:"baz"`
+	}
+	type HTTPOptions struct {
+		Listener string `hcl:"listener,label"`
+		Address  string `hcl:"address"`
+		Secure   bool   `hcl:"secure"`
+	}
+	type GRPCOptions struct {
+		Listener string `hcl:"listener,label"`
+		Address  string `hcl:"address"`
+	}
+	type MQTTOptions struct {
+		Listener string   `hcl:"listener,label"`
+		Address  string   `hcl:"address"`
+		Topics   []string `hcl:"topics"`
+	}
+
 	type Service struct {
 		Name string   `hcl:"name,label"`
 		Exe  []string `hcl:"executable"`
@@ -17,10 +37,12 @@ func ExampleEncodeIntoBody() {
 		Arch string `hcl:"arch"`
 	}
 	type App struct {
-		Name        string       `hcl:"name"`
-		Desc        string       `hcl:"description"`
-		Constraints *Constraints `hcl:"constraints,block"`
-		Services    []Service    `hcl:"service,block"`
+		Name        string         `hcl:"name"`
+		Desc        string         `hcl:"description"`
+		Constraints *Constraints   `hcl:"constraints,block"`
+		Services    []Service      `hcl:"service,block"`
+		Options     [3]interface{} `hcl:"option,block"`
+		Dynamic     interface{}    `hcl:"whatever,block"`
 	}
 
 	app := App{
@@ -39,6 +61,26 @@ func ExampleEncodeIntoBody() {
 				Name: "worker",
 				Exe:  []string{"./worker"},
 			},
+		},
+		Options: [3]interface{}{
+			HTTPOptions{
+				Listener: "http",
+				Address:  ":8080",
+			},
+			GRPCOptions{
+				Listener: "grpc",
+				Address:  ":5051",
+			},
+			MQTTOptions{
+				Listener: "mqtt",
+				Address:  ":1883",
+				Topics:   []string{"foo", "bar"},
+			},
+		},
+		Dynamic: DynamicExample{
+			Foo: "foo",
+			Bar: 42,
+			Baz: true,
 		},
 	}
 
@@ -61,4 +103,23 @@ func ExampleEncodeIntoBody() {
 	// service "worker" {
 	//   executable = ["./worker"]
 	// }
+	//
+	// option "http" {
+	//   address = ":8080"
+	//   secure  = false
+	// }
+	// option "grpc" {
+	//   address = ":5051"
+	// }
+	// option "mqtt" {
+	//   address = ":1883"
+	//   topics  = ["foo", "bar"]
+	// }
+	//
+	// whatever {
+	//   foo = "foo"
+	//   bar = 42
+	//   baz = true
+	// }
+
 }


### PR DESCRIPTION
We use HCL encoder to build dynamic configs for our services, unfortunately, there is no ability to use different types in the block. 
Let's say we have App config with additional options and couple of possible types:
```go
type App struct {
	. . .
	Option []interface{} `hcl:"option,block"`
}

type HTTPOptions struct {
	Listener string `hcl:"listener,label"`
	Address  string `hcl:"address"`
	Secure   bool   `hcl:"secure"`
}

type MQTTOptions struct {
	Listener string   `hcl:"listener,label"`
	Address  string   `hcl:"address"`
	Topics   []string `hcl:"topics"`
}
```

We would like to be able to provide all of them:
```go
var config = App{
	Options: []interface{}{
		HTTPOptions{
			Listener: "http",
			Address:  ":8080",
		},
		MQTTOptions{
			Listener: "mqtt",
			Address:  ":1883",
			Topics:   []string{"foo", "bar"},
		},
	},
} 
```

Desired output:
```hcl
option "http" {
  address = ":8080"
  secure  = false
}
option "mqtt" {
  address = ":1883"
  topics  = ["foo", "bar"]
}
```

Or maybe someone could suggest more elegant way :thinking: 