### PR TITLE
Unmark conditional values before checking their truthiness

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -624,6 +624,8 @@ func (e *ConditionalExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostic
 		return cty.UnknownVal(resultType), diags
 	}
 
+	// Unmark result before testing for truthiness
+	condResult, _ = condResult.UnmarkDeep()
 	if condResult.True() {
 		diags = append(diags, trueDiags...)
 		if convs[0] != nil {

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1582,6 +1582,18 @@ EOT
 			cty.DynamicVal,
 			0,
 		},
+		{ // marked conditional
+			`var.foo ? 1 : 0`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"var": cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.BoolVal(true),
+					}).Mark("sensitive"),
+				},
+			},
+			cty.NumberIntVal(1),
+			0,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
In conditional expressions that involve a marked value, unmark the value before inspecting its truthiness. This avoids a mark panic in cty when checking the value. Related to https://github.com/hashicorp/terraform/issues/27107