### PR TITLE
gohcl: Add support for optional-block

### DIFF
--- a/gohcl/decode.go
+++ b/gohcl/decode.go
@@ -163,7 +163,7 @@ func decodeBodyToStruct(body hcl.Body, ctx *hcl.EvalContext, val reflect.Value) 
 				if val.Field(fieldIdx).IsNil() {
 					val.Field(fieldIdx).Set(reflect.Zero(field.Type))
 				}
-			} else {
+			} else if optional, ok := tags.Optional[typeName]; !(optional && ok) {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  fmt.Sprintf("Missing %s block", typeName),

--- a/gohcl/schema.go
+++ b/gohcl/schema.go
@@ -152,6 +152,9 @@ func getFieldTags(ty reflect.Type) *fieldTags {
 			ret.Attributes[name] = i
 		case "block":
 			ret.Blocks[name] = i
+		case "optional-block":
+			ret.Blocks[name] = i
+			ret.Optional[name] = true
 		case "label":
 			ret.Labels = append(ret.Labels, labelField{
 				FieldIndex: i,


### PR DESCRIPTION
optional-block allows for a block to be omitted when parsing an .hcl file

Fixes #431