### PR TITLE
Return an error for invalid for expressions with marks

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1175,6 +1175,19 @@ func (e *ForExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 				continue
 			}
 
+			if key.IsMarked() {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity:    hcl.DiagError,
+					Summary:     "Invalid object key",
+					Detail:      "Marked values cannot be used as object keys.",
+					Subject:     e.KeyExpr.Range().Ptr(),
+					Context:     &e.SrcRange,
+					Expression:  e.KeyExpr,
+					EvalContext: childCtx,
+				})
+				continue
+			}
+
 			val, valDiags := e.ValExpr.Value(childCtx)
 			diags = append(diags, valDiags...)
 

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -889,7 +889,37 @@ upper(
 			}).Mark("sensitive"),
 			0,
 		},
-
+		{ // Marked map member carries marks through
+			`{for k, v in things: k => !v}`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.MapVal(map[string]cty.Value{
+						"a": cty.True.Mark("sensitive"),
+						"b": cty.False,
+					}),
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.False.Mark("sensitive"),
+				"b": cty.True,
+			}),
+			0,
+		},
+		{ // Error when using marked value as object key
+			`{for v in things: v => "${v}-friend"}`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.MapVal(map[string]cty.Value{
+						"a": cty.StringVal("rosie").Mark("sensitive"),
+						"b": cty.StringVal("robin"),
+					}),
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"robin": cty.StringVal("robin-friend"),
+			}),
+			1,
+		},
 		{
 			`[{name: "Steve"}, {name: "Ermintrude"}].*.name`,
 			nil,


### PR DESCRIPTION
Rather than allowing a panic to occur, return an error for "Invalid object key" if a user attempts to write a for expression that would convert the marked value to an unmarked string (by using it as the object key).

Prior to this change, the following code would panic:

```
> local.baz
{
  "a" = (sensitive)
  "b" = "dog"
}
> {for  v in local.baz: v => 1 }
```

After:
```
> {for  v in local.baz: v => 1 }

>  
Error: Invalid object key

  on <console-input> line 1:
  (source code not available) # Terraform console usage

Marked values cannot be used as object keys.
```