### PR TITLE
Error if attempting to use marked value as key

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -825,6 +825,19 @@ func (e *ObjectConsExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics
 			continue
 		}
 
+		if key.IsMarked() {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity:    hcl.DiagError,
+				Summary:     "Marked value as key",
+				Detail:      "Can't use a marked value as a key.",
+				Subject:     item.ValueExpr.Range().Ptr(),
+				Expression:  item.KeyExpr,
+				EvalContext: ctx,
+			})
+			known = false
+			continue
+		}
+
 		var err error
 		key, err = convert.Convert(key, cty.String)
 		if err != nil {

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -507,6 +507,19 @@ upper(
 			0,
 		},
 		{
+			// Marked values as object keys
+			`{(var.greeting) = "world", "goodbye" = "earth"}`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"var": cty.ObjectVal(map[string]cty.Value{
+						"greeting": cty.StringVal("hello").Mark("marked"),
+					}),
+				},
+			},
+			cty.DynamicVal,
+			1,
+		},
+		{
 			`{"${var.greeting}" = "world"}`,
 			&hcl.EvalContext{
 				Variables: map[string]cty.Value{


### PR DESCRIPTION
When evaluating an HCL expression attempting to use a marked value as an object key, return an error rather than falling through to the cty panic.

The error text mimics similar errors in the area, but could be more similar to #433 (or changed in either location) if preferred.