### PR TITLE
hclsyntax: Fix panic for marked collection splat

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1452,6 +1452,9 @@ func (e *SplatExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 		return cty.UnknownVal(ty), diags
 	}
 
+	// Unmark the collection, and save the marks to apply to the returned
+	// collection result
+	sourceVal, marks := sourceVal.Unmark()
 	vals := make([]cty.Value, 0, sourceVal.LengthInt())
 	it := sourceVal.ElementIterator()
 	if ctx == nil {
@@ -1486,9 +1489,9 @@ func (e *SplatExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 			diags = append(diags, tyDiags...)
 			return cty.ListValEmpty(ty.ElementType()), diags
 		}
-		return cty.ListVal(vals), diags
+		return cty.ListVal(vals).WithMarks(marks), diags
 	default:
-		return cty.TupleVal(vals), diags
+		return cty.TupleVal(vals).WithMarks(marks), diags
 	}
 }
 

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1172,6 +1172,26 @@ upper(
 			}).Mark("sensitive"),
 			0,
 		},
+		{ // splat with collection with sensitive elements
+			`maps.*.x`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"maps": cty.ListVal([]cty.Value{
+						cty.MapVal(map[string]cty.Value{
+							"x": cty.StringVal("foo").Mark("sensitive"),
+						}),
+						cty.MapVal(map[string]cty.Value{
+							"x": cty.StringVal("bar"),
+						}),
+					}),
+				},
+			},
+			cty.ListVal([]cty.Value{
+				cty.StringVal("foo").Mark("sensitive"),
+				cty.StringVal("bar"),
+			}),
+			0,
+		},
 		{
 			`["hello"][0]`,
 			nil,

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1156,7 +1156,22 @@ upper(
 			}),
 			1,
 		},
-
+		{ // splat with sensitive collection
+			`maps.*.enabled`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"maps": cty.ListVal([]cty.Value{
+						cty.MapVal(map[string]cty.Value{"enabled": cty.True}),
+						cty.MapVal(map[string]cty.Value{"enabled": cty.False}),
+					}).Mark("sensitive"),
+				},
+			},
+			cty.ListVal([]cty.Value{
+				cty.True,
+				cty.False,
+			}).Mark("sensitive"),
+			0,
+		},
 		{
 			`["hello"][0]`,
 			nil,


### PR DESCRIPTION
Fixes [this downstream Terraform bug](https://github.com/hashicorp/terraform/issues/27329). I couldn't find any other instances of calling `LengthInt` on a possibly-marked collection.