### PR TITLE
hclsyntax: Fix for expression marked conditional

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1143,7 +1143,17 @@ func (e *ForExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 					continue
 				}
 
-				if include.False() {
+				// Extract and merge marks from the include expression into the
+				// main set of marks
+				includeUnmarked, includeMarks := include.Unmark()
+				if marks == nil {
+					marks = includeMarks
+				} else {
+					for k := range includeMarks {
+						marks[k] = struct{}{}
+					}
+				}
+				if includeUnmarked.False() {
 					// Skip this element
 					continue
 				}
@@ -1300,7 +1310,17 @@ func (e *ForExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 					continue
 				}
 
-				if include.False() {
+				// Extract and merge marks from the include expression into the
+				// main set of marks
+				includeUnmarked, includeMarks := include.Unmark()
+				if marks == nil {
+					marks = includeMarks
+				} else {
+					for k := range includeMarks {
+						marks[k] = struct{}{}
+					}
+				}
+				if includeUnmarked.False() {
 					// Skip this element
 					continue
 				}

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -933,6 +933,42 @@ upper(
 			}),
 			1,
 		},
+		{ // Sequence for loop with marked conditional expression
+			`[for x in things: x if x != secret]`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.ListVal([]cty.Value{
+						cty.StringVal("a"),
+						cty.StringVal("b"),
+						cty.StringVal("c"),
+					}),
+					"secret": cty.StringVal("b").Mark("sensitive"),
+				},
+			},
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("c"),
+			}).Mark("sensitive"),
+			0,
+		},
+		{ // Map for loop with marked conditional expression
+			`{ for k, v in things: k => v if k != secret }`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.MapVal(map[string]cty.Value{
+						"a": cty.True,
+						"b": cty.False,
+						"c": cty.False,
+					}),
+					"secret": cty.StringVal("b").Mark("sensitive"),
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.True,
+				"c": cty.False,
+			}).Mark("sensitive"),
+			0,
+		},
 		{
 			`[{name: "Steve"}, {name: "Ermintrude"}].*.name`,
 			nil,


### PR DESCRIPTION
These test cases both panic without the associated changes, because `.False()` on a marked value is invalid.

If the conditional expression in a for expression evaluates to a marked value, we need to ignore the marks before testing it. Since this result will not interpolate into the result, dropping the mark here seems reasonable for now.