### PR TITLE
avoid panics with marked Index key values

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -95,6 +95,7 @@ func Index(collection, key cty.Value, srcRange *Range) (cty.Value, Diagnostics) 
 			// division rather than integer division.
 			if (ty.IsListType() || ty.IsTupleType()) && key.Type().Equals(cty.Number) {
 				if key.IsKnown() && !key.IsNull() {
+					key, _ := key.Unmark()
 					bf := key.AsBigFloat()
 					if _, acc := bf.Int(nil); acc != big.Exact {
 						return cty.DynamicVal, Diagnostics{
@@ -143,6 +144,7 @@ func Index(collection, key cty.Value, srcRange *Range) (cty.Value, Diagnostics) 
 			return cty.DynamicVal, nil
 		}
 
+		key, _ = key.Unmark()
 		attrName := key.AsString()
 
 		if !ty.HasAttribute(attrName) {


### PR DESCRIPTION
Index keys must be unmarked to convert them to a primitive type.

Add tests for overall `Index` test coverage.