### PR TITLE
Add vault fuzzers

### DIFF
--- a/vault-fuzzers/fuzz.go
+++ b/vault-fuzzers/fuzz.go
@@ -1,0 +1,25 @@
+// +build gofuzz
+
+package fuzz
+
+import (
+	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/random"
+	"github.com/hashicorp/vault/vault"
+)
+
+func FuzzParseACLPolicy(data []byte) int {
+	_, err := vault.ParseACLPolicy(namespace.RootNamespace, string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzParsePolicy(data []byte) int {
+	_, err := random.ParsePolicy(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds two fuzzers that were originally submitted directly to Vault: https://github.com/hashicorp/vault/pull/10475. It was suggested on the PR to submit the fuzzers here.

As mentioned on the Vault PR, one of the fuzzers found a bug that was fixed here: https://github.com/hashicorp/hcl/pull/410. The bug was submitted privately.

I am therefore committing these two fuzzers with the suggestion of setting up continuous fuzzing for HCL through OSS-fuzz - This is something I will be happy to do. This will allow Google to run the fuzzers continuously and notify maintainers in case bugs are found. The service is offered free of charge to open source projects with the implied expectation that bugs are fixed so that the resources spent on running Vaults fuzzers are put to good use. 

I have recently published [an article](https://adalogics.com/blog/the-importance-of-continuity-in-fuzzing-cve-2020-28362) about the importance of running fuzzers continuously.