### PR TITLE
Fix parseQuotedStringLiteral zero end range

### DIFF
--- a/hclsyntax/parser.go
+++ b/hclsyntax/parser.go
@@ -1661,7 +1661,7 @@ func (p *parser) parseQuotedStringLiteral() (string, hcl.Range, hcl.Diagnostics)
 
 	var diags hcl.Diagnostics
 	ret := &bytes.Buffer{}
-	var cQuote Token
+	var endRange hcl.Range
 
 Token:
 	for {
@@ -1669,7 +1669,7 @@ Token:
 		switch tok.Type {
 
 		case TokenCQuote:
-			cQuote = tok
+			endRange = tok.Range
 			break Token
 
 		case TokenQuotedLit:
@@ -1712,6 +1712,7 @@ Token:
 				Subject:  &tok.Range,
 				Context:  hcl.RangeBetween(oQuote.Range, tok.Range).Ptr(),
 			})
+			endRange = tok.Range
 			break Token
 
 		default:
@@ -1724,13 +1725,14 @@ Token:
 				Context:  hcl.RangeBetween(oQuote.Range, tok.Range).Ptr(),
 			})
 			p.recover(TokenCQuote)
+			endRange = tok.Range
 			break Token
 
 		}
 
 	}
 
-	return ret.String(), hcl.RangeBetween(oQuote.Range, cQuote.Range), diags
+	return ret.String(), hcl.RangeBetween(oQuote.Range, endRange), diags
 }
 
 // ParseStringLiteralToken processes the given token, which must be either a

--- a/hclsyntax/parser_test.go
+++ b/hclsyntax/parser_test.go
@@ -2484,6 +2484,64 @@ block "valid" {}
 				},
 			},
 		},
+		{
+			`block "unterminated_string "name" {}`,
+			2, // "Invalid string literal" and "Invalid block definition"
+			&Body{
+				Attributes: Attributes{},
+				Blocks: Blocks{
+					&Block{
+						Type:   "block",
+						Labels: []string{"unterminated_string ", "name", " {}"},
+						Body: &Body{
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+								End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+							},
+							EndRange: hcl.Range{
+								Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+								End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+							},
+						},
+
+						TypeRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+						},
+						LabelRanges: []hcl.Range{
+							{
+								Start: hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:   hcl.Pos{Line: 1, Column: 29, Byte: 28},
+							},
+							{
+								Start: hcl.Pos{Line: 1, Column: 29, Byte: 28},
+								End:   hcl.Pos{Line: 1, Column: 33, Byte: 32},
+							},
+							{
+								Start: hcl.Pos{Line: 1, Column: 33, Byte: 32},
+								End:   hcl.Pos{Line: 1, Column: 37, Byte: 36},
+							},
+						},
+						OpenBraceRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+						},
+						CloseBraceRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+						},
+					},
+				},
+				SrcRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:   hcl.Pos{Line: 1, Column: 37, Byte: 36},
+				},
+				EndRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 37, Byte: 36},
+					End:   hcl.Pos{Line: 1, Column: 37, Byte: 36},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
If a block label had an invalid quoted string literal, the parser would previously create label ranges with uninitialized `End` values. For Terraform, this would eventually percolate into invalid diagnostic output due to the assumption that the end of a range is always greater than or equal to the start: see https://github.com/hashicorp/terraform/issues/28587 and https://github.com/hashicorp/terraform/pull/28598

This commit addresses this by using the terminating token's position as the end of the range, even if it's not a closing quote.