### PR TITLE
Add support for dynamic blocks when using the ',remain'

### DIFF
--- a/ext/dynblock/expand_body.go
+++ b/ext/dynblock/expand_body.go
@@ -254,7 +254,9 @@ func (b *expandBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
 	// blocks aren't allowed in JustAttributes mode and this body can
 	// only produce blocks, so we'll just pass straight through to our
 	// underlying body here.
-	return b.original.JustAttributes()
+	attrs, diags := b.original.JustAttributes()
+	attrs = b.prepareAttributes(attrs)
+	return attrs, diags
 }
 
 func (b *expandBody) MissingItemRange() hcl.Range {


### PR DESCRIPTION
Background:

We wanted a `map[string]cty.Value` from HCL. We tried using a `map` in `cty` but that means all the values should be of the same type, e.g. this fails:

```hcl
fields = {
  my_bool = false
  my_string = "string"
}
```

So we resorted to using a block `fields { ... }` with the `,remain` tag and the following go struct:

```go
type DataFields struct {
	Values map[string]cty.Value `hcl:",remain"`
}
```

And now we can do:

```hcl
fields {
  my_bool = true
  my_string = "string"
}
```

However this fails inside the `dynamic` block because the `body.JustAttributes()` method does not respect the scope/iteration inside a `dynamic` block. This small PR addresses this and would be great if you accept this PR.