### PR TITLE
hclsyntax: Fix incorrect examples of object expressions in the spec

### DIFF
--- a/hclsyntax/spec.md
+++ b/hclsyntax/spec.md
@@ -293,18 +293,20 @@ Between the open and closing delimiters of these sequences, newline sequences
 are ignored as whitespace.
 
 There is a syntax ambiguity between _for expressions_ and collection values
-whose first element is a reference to a variable named `for`. The
-_for expression_ interpretation has priority, so to produce a tuple whose
-first element is the value of a variable named `for`, or an object with a
-key named `for`, use parentheses to disambiguate:
+whose first element starts with an identifier named `for`. The _for expression_
+interpretation has priority, so to write a key literally named `for`
+or an expression derived from a variable named `for` you must use parentheses
+or quotes to disambiguate:
 
 - `[for, foo, baz]` is a syntax error.
 - `[(for), foo, baz]` is a tuple whose first element is the value of variable
   `for`.
-- `{for: 1, baz: 2}` is a syntax error.
-- `{(for): 1, baz: 2}` is an object with an attribute literally named `for`.
-- `{baz: 2, for: 1}` is equivalent to the previous example, and resolves the
+- `{for = 1, baz = 2}` is a syntax error.
+- `{"for" = 1, baz = 2}` is an object with an attribute literally named `for`.
+- `{baz = 2, for = 1}` is equivalent to the previous example, and resolves the
   ambiguity by reordering.
+- `{(for) = 1, baz = 2}` is an object with a key with the same value as the
+  variable `for`.
 
 ### Template Expressions
 


### PR DESCRIPTION
In the text talking about how to resolve the ambiguity between `for` expressions and values/keys called `for` there was previously an incorrect statement about the behavior of `(for)` as an object key.

That situation causes HCL to take the value of a variable named `for`. To get the literal string `"for"` we must instead write the name in quotes, similarly to how we'd represent a key string that includes characters which HCL doesn't admit into an identifier.

[Rendered version of the relevant section](https://github.com/hashicorp/hcl/blob/b-hclsyntax-spec-for-key/hclsyntax/spec.md#collection-values)
