### PR TITLE
NEWLINE also acts as an objectelem separator

### DIFF
--- a/hclsyntax/spec.md
+++ b/hclsyntax/spec.md
@@ -271,7 +271,7 @@ tuple = "[" (
     (Expression ("," Expression)* ","?)?
 ) "]";
 object = "{" (
-    (objectelem ("," objectelem)* ","?)?
+    (objectelem ((","|NEWLINE) objectelem)* ","?)?
 ) "}";
 objectelem = (Identifier | Expression) ("=" | ":") Expression;
 ```


### PR DESCRIPTION
This is perhaps not the best way to capture this - but I was hacking on a parser and the grammar seems to neither fit, nor be resolved by prose in this case.