### PR TITLE
Align `hcl.Block` & `hclsyntax.Block` `DefRange`

### DIFF
--- a/hclsyntax/navigation_test.go
+++ b/hclsyntax/navigation_test.go
@@ -112,12 +112,12 @@ data "another" "baz" {
 	}{
 		{0, hcl.Range{}},
 		{2, hcl.Range{}},
-		{4, hcl.Range{Filename: "", Start: hcl.Pos{Line: 4, Column: 1, Byte: 3}, End: hcl.Pos{Line: 4, Column: 11, Byte: 13}}},
-		{17, hcl.Range{Filename: "", Start: hcl.Pos{Line: 7, Column: 1, Byte: 17}, End: hcl.Pos{Line: 7, Column: 25, Byte: 41}}},
-		{25, hcl.Range{Filename: "", Start: hcl.Pos{Line: 7, Column: 1, Byte: 17}, End: hcl.Pos{Line: 7, Column: 25, Byte: 41}}},
-		{45, hcl.Range{Filename: "", Start: hcl.Pos{Line: 10, Column: 1, Byte: 45}, End: hcl.Pos{Line: 10, Column: 33, Byte: 77}}},
-		{142, hcl.Range{Filename: "", Start: hcl.Pos{Line: 18, Column: 1, Byte: 142}, End: hcl.Pos{Line: 18, Column: 23, Byte: 164}}},
-		{180, hcl.Range{Filename: "", Start: hcl.Pos{Line: 18, Column: 1, Byte: 142}, End: hcl.Pos{Line: 18, Column: 23, Byte: 164}}},
+		{4, hcl.Range{Filename: "", Start: hcl.Pos{Line: 4, Column: 1, Byte: 3}, End: hcl.Pos{Line: 4, Column: 9, Byte: 11}}},
+		{17, hcl.Range{Filename: "", Start: hcl.Pos{Line: 7, Column: 1, Byte: 17}, End: hcl.Pos{Line: 7, Column: 23, Byte: 39}}},
+		{25, hcl.Range{Filename: "", Start: hcl.Pos{Line: 7, Column: 1, Byte: 17}, End: hcl.Pos{Line: 7, Column: 23, Byte: 39}}},
+		{45, hcl.Range{Filename: "", Start: hcl.Pos{Line: 10, Column: 1, Byte: 45}, End: hcl.Pos{Line: 10, Column: 31, Byte: 75}}},
+		{142, hcl.Range{Filename: "", Start: hcl.Pos{Line: 18, Column: 1, Byte: 142}, End: hcl.Pos{Line: 18, Column: 21, Byte: 162}}},
+		{180, hcl.Range{Filename: "", Start: hcl.Pos{Line: 18, Column: 1, Byte: 142}, End: hcl.Pos{Line: 18, Column: 21, Byte: 162}}},
 		{99999, hcl.Range{}},
 	}
 

--- a/hclsyntax/structure.go
+++ b/hclsyntax/structure.go
@@ -13,17 +13,12 @@ func (b *Block) AsHCLBlock() *hcl.Block {
 		return nil
 	}
 
-	lastHeaderRange := b.TypeRange
-	if len(b.LabelRanges) > 0 {
-		lastHeaderRange = b.LabelRanges[len(b.LabelRanges)-1]
-	}
-
 	return &hcl.Block{
 		Type:   b.Type,
 		Labels: b.Labels,
 		Body:   b.Body,
 
-		DefRange:    hcl.RangeBetween(b.TypeRange, lastHeaderRange),
+		DefRange:    b.DefRange(),
 		TypeRange:   b.TypeRange,
 		LabelRanges: b.LabelRanges,
 	}
@@ -390,5 +385,9 @@ func (b *Block) Range() hcl.Range {
 }
 
 func (b *Block) DefRange() hcl.Range {
-	return hcl.RangeBetween(b.TypeRange, b.OpenBraceRange)
+	lastHeaderRange := b.TypeRange
+	if len(b.LabelRanges) > 0 {
+		lastHeaderRange = b.LabelRanges[len(b.LabelRanges)-1]
+	}
+	return hcl.RangeBetween(b.TypeRange, lastHeaderRange)
 }


### PR DESCRIPTION
This patch fixes a minor discrepancy between `hclsyntax` and `hcl` in how DefRange is computed for a block.

DefRange of the "higher-level" `hcl.Block` (typically used by most applications) ends with the last label.

DefRange of the "lower-level" `hclsyntax.Block` ended with the opening brace `{` (i.e. at least 2 characters further).

Here we align the low-level API with the high-level one, meaning that most consumers should not be affected by this change, partly because they use `hcl.Block` (which isn't changing) or because they use DefRange to inform some non-critical decisions such as enriching diagnostics.

--- 
I ran into this discrepancy when working on adding support to JSON syntax to the language server in https://github.com/hashicorp/hcl-lang/pull/88