### PR TITLE
hclsyntax: Clarify Body.EndRange comment

### DIFF
--- a/hclsyntax/structure.go
+++ b/hclsyntax/structure.go
@@ -40,7 +40,7 @@ type Body struct {
 	hiddenBlocks map[string]struct{}
 
 	SrcRange hcl.Range
-	EndRange hcl.Range // Final token of the body, for reporting missing items
+	EndRange hcl.Range // Final token of the body (zero-length range)
 }
 
 // Assert that *Body implements hcl.Body


### PR DESCRIPTION
As discussed via Slack this field is no longer (and probably never was) used for reporting missing items.

Instead `Body` has a dedicated method for this:

https://github.com/hashicorp/hcl/blob/2ebbb5d2dcc67881774d2b81d1497a55452e890f/hclsyntax/structure.go#L281-L287