### PR TITLE
map[string]interface{} encoding

### DIFF
--- a/gohcl/encode.go
+++ b/gohcl/encode.go
@@ -2,6 +2,7 @@ package gohcl
 
 import (
 	"fmt"
+	"github.com/zclconf/go-cty/cty"
 	"reflect"
 	"sort"
 
@@ -64,6 +65,18 @@ func EncodeAsBlock(val interface{}, blockType string) *hclwrite.Block {
 		rv = rv.Elem()
 		ty = rv.Type()
 	}
+
+	if(ty.Kind() == reflect.Map){
+		block := hclwrite.NewBlock(blockType, nil)
+		body := block.Body()
+		for _, e := range rv.MapKeys() {
+			v := rv.MapIndex(e)
+			fieldVal := getFieldVal(v)
+			body.SetAttributeValue(e.String(), fieldVal)
+		}
+		return block
+	}
+
 	if ty.Kind() != reflect.Struct {
 		panic(fmt.Sprintf("value is %s, not struct", ty.Kind()))
 	}
@@ -128,17 +141,7 @@ func populateBody(rv reflect.Value, ty reflect.Type, tags *fieldTags, dst *hclwr
 				prevWasBlock = false
 			}
 
-			valTy, err := gocty.ImpliedType(fieldVal.Interface())
-			if err != nil {
-				panic(fmt.Sprintf("cannot encode %T as HCL expression: %s", fieldVal.Interface(), err))
-			}
-
-			val, err := gocty.ToCtyValue(fieldVal.Interface(), valTy)
-			if err != nil {
-				// This should never happen, since we should always be able
-				// to decode into the implied type.
-				panic(fmt.Sprintf("failed to encode %T as %#v: %s", fieldVal.Interface(), valTy, err))
-			}
+			val := getFieldVal(fieldVal)
 
 			dst.SetAttributeValue(name, val)
 
@@ -188,4 +191,20 @@ func populateBody(rv reflect.Value, ty reflect.Type, tags *fieldTags, dst *hclwr
 			}
 		}
 	}
+}
+
+func getFieldVal(fieldVal reflect.Value) cty.Value {
+	valTy, err := gocty.ImpliedType(fieldVal.Interface())
+	if err != nil {
+		panic(fmt.Sprintf("cannot encode %T as HCL expression: %s", fieldVal.Interface(), err))
+	}
+
+	val, err := gocty.ToCtyValue(fieldVal.Interface(), valTy)
+	if err != nil {
+		// This should never happen, since we should always be able
+		// to decode into the implied type.
+		panic(fmt.Sprintf("failed to encode %T as %#v: %s", fieldVal.Interface(), valTy, err))
+	}
+
+	return val
 }

--- a/gohcl/encode_test.go
+++ b/gohcl/encode_test.go
@@ -21,6 +21,8 @@ func ExampleEncodeIntoBody() {
 		Desc        string       `hcl:"description"`
 		Constraints *Constraints `hcl:"constraints,block"`
 		Services    []Service    `hcl:"service,block"`
+		Config		map[string]interface{} `hcl:"config,block"`
+		Test		map[string]interface{} `hcl:"test,block"`
 	}
 
 	app := App{
@@ -40,6 +42,8 @@ func ExampleEncodeIntoBody() {
 				Exe:  []string{"./worker"},
 			},
 		},
+		Config: map[string]interface{}{"image": "dockerimage"},
+		Test: 	map[string]interface{}{"strings": []string{"test","2134"}},
 	}
 
 	f := hclwrite.NewEmptyFile()
@@ -61,4 +65,12 @@ func ExampleEncodeIntoBody() {
 	// service "worker" {
 	//   executable = ["./worker"]
 	// }
+	//
+	//config {
+	//   image = "dockerimage"
+	//}
+	//
+	//test {
+	//   strings = ["test", "2134"]
+	//}
 }


### PR DESCRIPTION
Was attempting to encode a nomad job spec and it failed with `panic:` value is map, not struct` since the struct contains a field of type map[string]interface{}, [here](https://github.com/hashicorp/nomad/blob/main/api/tasks.go#L666).

Added handling for this type while encoding.

