### PR TITLE
Increase performance and reduce allocations in `hclsyntax.LexConfig`

### DIFF
--- a/hclsyntax/public_test.go
+++ b/hclsyntax/public_test.go
@@ -2,6 +2,8 @@ package hclsyntax
 
 import (
 	"testing"
+
+	"github.com/hashicorp/hcl/v2"
 )
 
 func TestValidIdentifier(t *testing.T) {
@@ -43,4 +45,20 @@ func TestValidIdentifier(t *testing.T) {
 			}
 		})
 	}
+}
+
+var T Tokens
+
+func BenchmarkLexConfig(b *testing.B) {
+	src := []byte("module \"once\" {\n  source = \"../modules/foo\"\n}\n\nmodule \"twice\" {\n  source = \"../modules/foo\"\n}\n")
+	filename := "testdata/dave/main.tf"
+	start := hcl.Pos{Line: 1, Column: 1, Byte: 0}
+
+	var tokens Tokens
+
+	for i := 0; i < b.N; i++ {
+		tokens, _ = LexConfig(src, filename, start)
+	}
+
+	T = tokens
 }

--- a/hclsyntax/token.go
+++ b/hclsyntax/token.go
@@ -191,7 +191,10 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 	toldBadUTF8 := 0
 
 	for _, tok := range tokens {
-		tokRange := tok.Range
+		tokRange := func() *hcl.Range {
+			r := tok.Range
+			return &r
+		}
 
 		switch tok.Type {
 		case TokenBitwiseAnd, TokenBitwiseOr, TokenBitwiseXor, TokenBitwiseNot:
@@ -210,7 +213,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Unsupported operator",
 					Detail:   fmt.Sprintf("Bitwise operators are not supported.%s", suggestion),
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				})
 				toldBitwise++
 			}
@@ -220,7 +223,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Unsupported operator",
 					Detail:   "\"**\" is not a supported operator. Exponentiation is not supported as an operator.",
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				})
 
 				toldExponent++
@@ -233,7 +236,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "The \"`\" character is not valid. To create a multi-line string, use the \"heredoc\" syntax, like \"<<EOT\".",
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				})
 			}
 			if toldBacktick <= 2 {
@@ -245,7 +248,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "Single quotes are not valid. Use double quotes (\") to enclose strings.",
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				}
 				diags = append(diags, newDiag)
 			}
@@ -258,7 +261,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "The \";\" character is not valid. Use newlines to separate arguments and blocks, and commas to separate items in collection values.",
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				})
 
 				toldSemicolon++
@@ -269,7 +272,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "Tab characters may not be used. The recommended indentation style is two spaces per indent.",
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				})
 
 				toldTabs++
@@ -280,7 +283,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character encoding",
 					Detail:   "All input files must be UTF-8 encoded. Ensure that UTF-8 encoding is selected in your editor.",
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				})
 
 				toldBadUTF8++
@@ -290,7 +293,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 				Severity: hcl.DiagError,
 				Summary:  "Invalid multi-line string",
 				Detail:   "Quoted strings may not be split over multiple lines. To produce a multi-line string, either use the \\n escape to represent a newline character or use the \"heredoc\" multi-line template syntax.",
-				Subject:  &tokRange,
+				Subject:  tokRange(),
 			})
 		case TokenInvalid:
 			chars := string(tok.Bytes)
@@ -300,14 +303,14 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "\"Curly quotes\" are not valid here. These can sometimes be inadvertently introduced when sharing code via documents or discussion forums. It might help to replace the character with a \"straight quote\".",
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				})
 			default:
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "This character is not used within the language.",
-					Subject:  &tokRange,
+					Subject:  tokRange(),
 				})
 			}
 		}

--- a/hclsyntax/token.go
+++ b/hclsyntax/token.go
@@ -191,8 +191,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 	toldBadUTF8 := 0
 
 	for _, tok := range tokens {
-		// copy token so it's safe to point to it
-		tok := tok
+		tokRange := tok.Range
 
 		switch tok.Type {
 		case TokenBitwiseAnd, TokenBitwiseOr, TokenBitwiseXor, TokenBitwiseNot:
@@ -211,7 +210,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Unsupported operator",
 					Detail:   fmt.Sprintf("Bitwise operators are not supported.%s", suggestion),
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				})
 				toldBitwise++
 			}
@@ -221,7 +220,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Unsupported operator",
 					Detail:   "\"**\" is not a supported operator. Exponentiation is not supported as an operator.",
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				})
 
 				toldExponent++
@@ -234,7 +233,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "The \"`\" character is not valid. To create a multi-line string, use the \"heredoc\" syntax, like \"<<EOT\".",
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				})
 			}
 			if toldBacktick <= 2 {
@@ -246,7 +245,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "Single quotes are not valid. Use double quotes (\") to enclose strings.",
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				}
 				diags = append(diags, newDiag)
 			}
@@ -259,7 +258,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "The \";\" character is not valid. Use newlines to separate arguments and blocks, and commas to separate items in collection values.",
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				})
 
 				toldSemicolon++
@@ -270,7 +269,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "Tab characters may not be used. The recommended indentation style is two spaces per indent.",
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				})
 
 				toldTabs++
@@ -281,7 +280,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character encoding",
 					Detail:   "All input files must be UTF-8 encoded. Ensure that UTF-8 encoding is selected in your editor.",
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				})
 
 				toldBadUTF8++
@@ -291,7 +290,7 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 				Severity: hcl.DiagError,
 				Summary:  "Invalid multi-line string",
 				Detail:   "Quoted strings may not be split over multiple lines. To produce a multi-line string, either use the \\n escape to represent a newline character or use the \"heredoc\" multi-line template syntax.",
-				Subject:  &tok.Range,
+				Subject:  &tokRange,
 			})
 		case TokenInvalid:
 			chars := string(tok.Bytes)
@@ -301,14 +300,14 @@ func checkInvalidTokens(tokens Tokens) hcl.Diagnostics {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "\"Curly quotes\" are not valid here. These can sometimes be inadvertently introduced when sharing code via documents or discussion forums. It might help to replace the character with a \"straight quote\".",
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				})
 			default:
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid character",
 					Detail:   "This character is not used within the language.",
-					Subject:  &tok.Range,
+					Subject:  &tokRange,
 				})
 			}
 		}


### PR DESCRIPTION
Hello, team. First of all, thank you for sharing this library.

While working on an internal project that makes use of this library to parse `.hcl` files to retrieve a list of used modules, I added some benchmarks and found that one of the bottlenecks that I had was in the `hclsyntax.LexConfig`. Further inspection highlighted `checkInvalidTokens` as one of the culprits (the other being `emitToken` which is in a generated file and thus I didn't want to mess much with).

I took the liberty to add a benchmark for `LexConfig` with a rather small HCL file, but that serves the purposes of finding if I was able to improve the results. Then I proceeded to run the benchmarks in the original code and found this results (only showing one line for brevity):

```
$ go test -benchmem -bench=. -benchtime=200000x -count=10 -memprofile=mem.pprof
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/hcl/v2/hclsyntax
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLexConfig-12             200000              9298 ns/op            8936 B/op         37 allocs/op
```

After that I've started to find where most of the allocations were being made, and found a spot that was making most of the reported allocations. Then I proceeded to try and reduce the allocations count and bytes, and the last commit got me this benchmark results (again showing only one line for brevity):

```
$ go test -benchmem -bench=. -benchtime=200000x -count=10 -memprofile=mem.pprof
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/hcl/v2/hclsyntax
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLexConfig-12             200000              7799 ns/op            6056 B/op          7 allocs/op
```

According to `benchstat`, the difference between both benchmarks is:

```
name          old time/op    new time/op    delta
LexConfig-12    9.27µs ± 0%    7.83µs ± 1%  -15.55%  (p=0.000 n=9+10)

name          old alloc/op   new alloc/op   delta
LexConfig-12    8.94kB ± 0%    6.06kB ± 0%  -32.23%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
LexConfig-12      37.0 ± 0%       7.0 ± 0%  -81.08%  (p=0.000 n=10+10)
```

As you can see this reduced the number of allocations in ~80% using 32% less bytes while doing so. As a side effect, performance got increased in 15%.

I hope you find this useful and worth of merging, thanks!