### PR TITLE
splat expression upgrading an unknown value should be unknown

### DIFF
--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1136,6 +1136,16 @@ upper(
 			0,
 		},
 		{
+			`unkstr[*]`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"unkstr": cty.UnknownVal(cty.String),
+				},
+			},
+			cty.UnknownVal(cty.Tuple([]cty.Type{cty.String})),
+			0,
+		},
+		{
 			`unkstr.*.name`,
 			&hcl.EvalContext{
 				Variables: map[string]cty.Value{
@@ -1164,9 +1174,7 @@ upper(
 					})),
 				},
 			},
-			cty.TupleVal([]cty.Value{
-				cty.UnknownVal(cty.String),
-			}),
+			cty.UnknownVal(cty.Tuple([]cty.Type{cty.String})),
 			0,
 		},
 		{


### PR DESCRIPTION
When a splat expression is used to upgrade an unknown value to a list with a single value, the result must be entirely unknown. 

Using a splat expression to expand a single non-list value will result in a list with a single value, unless that value is null, in which case it will result in an empty list. This means that if `ukstr` is an unknown string value, then `unkstr[*]` could either result in a list of 1 string value, or an empty list, hence the result of `unkstr[*]` must be entirely unknown. 

