### PR TITLE
unknown upgraded splat values may have no elements

### DIFF
--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1142,7 +1142,7 @@ upper(
 					"unkstr": cty.UnknownVal(cty.String),
 				},
 			},
-			cty.UnknownVal(cty.Tuple([]cty.Type{cty.String})),
+			cty.DynamicVal,
 			0,
 		},
 		{
@@ -1152,7 +1152,7 @@ upper(
 					"unkstr": cty.UnknownVal(cty.String),
 				},
 			},
-			cty.UnknownVal(cty.Tuple([]cty.Type{cty.DynamicPseudoType})),
+			cty.DynamicVal,
 			1, // a string has no attribute "name"
 		},
 		{
@@ -1174,7 +1174,19 @@ upper(
 					})),
 				},
 			},
-			cty.UnknownVal(cty.Tuple([]cty.Type{cty.String})),
+			cty.DynamicVal,
+			0,
+		},
+		{
+			`unkobj.*.names`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"unkobj": cty.UnknownVal(cty.Object(map[string]cty.Type{
+						"names": cty.List(cty.String),
+					})),
+				},
+			},
+			cty.DynamicVal,
 			0,
 		},
 		{


### PR DESCRIPTION
Follow up for #493, which ensured the value of an upgraded splat expression on an unknown value is unknown, but could result in the wrong type. When the previous PR was updated to allow specific types for expressions with attribute selectors after the splat, the resulting types were still unknown tuples even though the number of elements could not be determined. 

When upgrading an unknown splat value, the resulting collection may have 0 elements if the value ends up being `null`. Since the final result may be a tuple type with 0 or 1 elements, the unknown value must also be dynamic.

