### PR TITLE
hclsyntax: test for invalid whitespace heredoc

### DIFF
--- a/hclsyntax/scan_tokens_test.go
+++ b/hclsyntax/scan_tokens_test.go
@@ -1508,6 +1508,150 @@ EOT
 			},
 		},
 		{
+			`<<EOT
+  hello world
+EOT
+`,
+			[]Token{
+				{
+					Type:  TokenOHeredoc,
+					Bytes: []byte("<<EOT\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 0, Line: 1, Column: 1},
+						End:   hcl.Pos{Byte: 6, Line: 2, Column: 1},
+					},
+				},
+				{
+					Type:  TokenStringLit,
+					Bytes: []byte("  hello world\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 6, Line: 2, Column: 1},
+						End:   hcl.Pos{Byte: 20, Line: 3, Column: 1},
+					},
+				},
+				{
+					Type:  TokenCHeredoc,
+					Bytes: []byte("EOT"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 20, Line: 3, Column: 1},
+						End:   hcl.Pos{Byte: 23, Line: 3, Column: 4},
+					},
+				},
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 23, Line: 3, Column: 4},
+						End:   hcl.Pos{Byte: 24, Line: 4, Column: 1},
+					},
+				},
+				{
+					Type:  TokenEOF,
+					Bytes: []byte{},
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 24, Line: 4, Column: 1},
+						End:   hcl.Pos{Byte: 24, Line: 4, Column: 1},
+					},
+				},
+			},
+		},
+		{
+			`<<-EOT
+  hello world
+EOT
+`,
+			[]Token{
+				{
+					Type:  TokenOHeredoc,
+					Bytes: []byte("<<-EOT\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 0, Line: 1, Column: 1},
+						End:   hcl.Pos{Byte: 7, Line: 2, Column: 1},
+					},
+				},
+				{
+					Type:  TokenStringLit,
+					Bytes: []byte("  hello world\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 7, Line: 2, Column: 1},
+						End:   hcl.Pos{Byte: 21, Line: 3, Column: 1},
+					},
+				},
+				{
+					Type:  TokenCHeredoc,
+					Bytes: []byte("EOT"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 21, Line: 3, Column: 1},
+						End:   hcl.Pos{Byte: 24, Line: 3, Column: 4},
+					},
+				},
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 24, Line: 3, Column: 4},
+						End:   hcl.Pos{Byte: 25, Line: 4, Column: 1},
+					},
+				},
+				{
+					Type:  TokenEOF,
+					Bytes: []byte{},
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 25, Line: 4, Column: 1},
+						End:   hcl.Pos{Byte: 25, Line: 4, Column: 1},
+					},
+				},
+			},
+		},
+		{
+			`<<-EOT
+  hello world
+ EOT
+`,
+			[]Token{
+				{
+					Type:  TokenOHeredoc,
+					Bytes: []byte("<<-EOT\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 0, Line: 1, Column: 1},
+						End:   hcl.Pos{Byte: 7, Line: 2, Column: 1},
+					},
+				},
+				{
+					Type:  TokenStringLit,
+					Bytes: []byte("  hello world\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 7, Line: 2, Column: 1},
+						End:   hcl.Pos{Byte: 21, Line: 3, Column: 1},
+					},
+				},
+				{
+					Type:  TokenCHeredoc,
+					Bytes: []byte(" EOT"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 21, Line: 3, Column: 1},
+						End:   hcl.Pos{Byte: 25, Line: 3, Column: 5},
+					},
+				},
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 25, Line: 3, Column: 5},
+						End:   hcl.Pos{Byte: 26, Line: 4, Column: 1},
+					},
+				},
+				{
+					Type:  TokenEOF,
+					Bytes: []byte{},
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 26, Line: 4, Column: 1},
+						End:   hcl.Pos{Byte: 26, Line: 4, Column: 1},
+					},
+				},
+			},
+		},
+		{
 			`<<EOF
 ${<<-EOF
 hello

--- a/hclsyntax/scan_tokens_test.go
+++ b/hclsyntax/scan_tokens_test.go
@@ -1606,6 +1606,172 @@ EOF
 				},
 			},
 		},
+		{
+			`<<EOF 
+hello
+EOF
+`,
+			// `EOF ` is not a valid identifier
+			// so `<<EOF ` is not a valid TokenOHeredoc
+			[]Token{
+				{
+					Type:  TokenLessThan,
+					Bytes: []byte("<"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 0, Line: 1, Column: 1},
+						End:   hcl.Pos{Byte: 1, Line: 1, Column: 2},
+					},
+				},
+				{
+					Type:  TokenLessThan,
+					Bytes: []byte("<"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 1, Line: 1, Column: 2},
+						End:   hcl.Pos{Byte: 2, Line: 1, Column: 3},
+					},
+				},
+				{
+					Type:  TokenIdent,
+					Bytes: []byte("EOF"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 2, Line: 1, Column: 3},
+						End:   hcl.Pos{Byte: 5, Line: 1, Column: 6},
+					},
+				},
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 6, Line: 1, Column: 7},
+						End:   hcl.Pos{Byte: 7, Line: 2, Column: 1},
+					},
+				},
+				{
+					Type:  TokenIdent,
+					Bytes: []byte("hello"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 7, Line: 2, Column: 1},
+						End:   hcl.Pos{Byte: 12, Line: 2, Column: 6},
+					},
+				},
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 12, Line: 2, Column: 6},
+						End:   hcl.Pos{Byte: 13, Line: 3, Column: 1},
+					},
+				},
+				{
+					Type:  TokenIdent,
+					Bytes: []byte("EOF"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 13, Line: 3, Column: 1},
+						End:   hcl.Pos{Byte: 16, Line: 3, Column: 4},
+					},
+				},
+
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 16, Line: 3, Column: 4},
+						End:   hcl.Pos{Byte: 17, Line: 4, Column: 1},
+					},
+				},
+				{
+					Type:  TokenEOF,
+					Bytes: []byte{},
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 17, Line: 4, Column: 1},
+						End:   hcl.Pos{Byte: 17, Line: 4, Column: 1},
+					},
+				},
+			},
+		},
+		{
+			`<<EOF 
+hello
+EOF 
+`,
+			// `EOF ` is not a valid identifier
+			// so `<<EOF ` is not a valid TokenOHeredoc
+			[]Token{
+				{
+					Type:  TokenLessThan,
+					Bytes: []byte("<"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 0, Line: 1, Column: 1},
+						End:   hcl.Pos{Byte: 1, Line: 1, Column: 2},
+					},
+				},
+				{
+					Type:  TokenLessThan,
+					Bytes: []byte("<"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 1, Line: 1, Column: 2},
+						End:   hcl.Pos{Byte: 2, Line: 1, Column: 3},
+					},
+				},
+				{
+					Type:  TokenIdent,
+					Bytes: []byte("EOF"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 2, Line: 1, Column: 3},
+						End:   hcl.Pos{Byte: 5, Line: 1, Column: 6},
+					},
+				},
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 6, Line: 1, Column: 7},
+						End:   hcl.Pos{Byte: 7, Line: 2, Column: 1},
+					},
+				},
+				{
+					Type:  TokenIdent,
+					Bytes: []byte("hello"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 7, Line: 2, Column: 1},
+						End:   hcl.Pos{Byte: 12, Line: 2, Column: 6},
+					},
+				},
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 12, Line: 2, Column: 6},
+						End:   hcl.Pos{Byte: 13, Line: 3, Column: 1},
+					},
+				},
+				{
+					Type:  TokenIdent,
+					Bytes: []byte("EOF"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 13, Line: 3, Column: 1},
+						End:   hcl.Pos{Byte: 16, Line: 3, Column: 4},
+					},
+				},
+
+				{
+					Type:  TokenNewline,
+					Bytes: []byte("\n"),
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 17, Line: 3, Column: 5},
+						End:   hcl.Pos{Byte: 18, Line: 4, Column: 1},
+					},
+				},
+				{
+					Type:  TokenEOF,
+					Bytes: []byte{},
+					Range: hcl.Range{
+						Start: hcl.Pos{Byte: 18, Line: 4, Column: 1},
+						End:   hcl.Pos{Byte: 18, Line: 4, Column: 1},
+					},
+				},
+			},
+		},
 
 		// Combinations
 		{


### PR DESCRIPTION
This PR adds two unit tests demonstrating invalid heredoc syntax, intended as a discussion point.

## Context

The following Terraform variable definition yields an error (https://github.com/hashicorp/terraform/issues/25410):
```hcl
policy = <<EOF 
{
  "hello": "hi"
}
EOF
```
Note the single whitespace character following "<<EOF" on the first line. Adding a matching whitespace character after the final "EOF" does not make it valid.

This is correct behaviour according to the HCL [spec](https://github.com/hashicorp/hcl/commit/2ebbb5d2dcc67881774d2b81d1497a55452e890f):
```ebnf
TemplateExpr = quotedTemplate | heredocTemplate;
quotedTemplate = (as defined in prose above);
heredocTemplate = (
    ("<<" | "<<-") Identifier Newline
    (content as defined in prose above)
    Identifier Newline
);
```

Since `Identifier` cannot contain whitespace, the first line does not introduce a heredoc template expression. A heredoc cannot be introduced by a line ending in whitespace.

## Other heredoc implementations

### Bash

Heredocs in Bash scripts behave the same way as HCL when encountering trailing whitespace. The following is not a valid heredoc:
```bash
cat << EOF 
myheredoc
EOF
```

Executing the above lines in an interactive Bash shell one-by-one, however, will result in a valid heredoc, since the shell strips trailing whitespace.

### Perl

Perl seems to allow trailing whitespace in the heredoc delimiter, so the following is valid:
```perl
print <<"END ";
myheredoc
END 
```

while the following is not, since there is no whitespace at the end of the terminating delimiter:
```perl
print <<"END ";
myheredoc
END
```

## Proposal

HCL's current behaviour is reasonable, and follows the ubiquitous Bash precedent, at the expense of some of Perl's flexibility (and eccentricity). Adding these tests will make it clearer to consumers. 

A better resolution to https://github.com/hashicorp/terraform/issues/25410 could involve a more specific error message, but I think the parser would need to do some sort of similarity calculation, which is a larger design question.