### PR TITLE
hclwrite: add support for tuple,nested object and function call

### DIFF
--- a/hclwrite/generate_test.go
+++ b/hclwrite/generate_test.go
@@ -536,3 +536,333 @@ func TestTokensForTraversal(t *testing.T) {
 		}
 	}
 }
+
+func TestTokensForTuple(t *testing.T) {
+	tests := map[string]struct {
+		Val  []Tokens
+		Want Tokens
+	}{
+		"no elements": {
+			nil,
+			Tokens{
+				{Type: hclsyntax.TokenOBrack, Bytes: []byte{'['}},
+				{Type: hclsyntax.TokenCBrack, Bytes: []byte{']'}},
+			},
+		},
+		"one element": {
+			[]Tokens{
+				TokensForValue(cty.StringVal("foo")),
+			},
+			Tokens{
+				{Type: hclsyntax.TokenOBrack, Bytes: []byte{'['}},
+				{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenQuotedLit, Bytes: []byte("foo")},
+				{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenCBrack, Bytes: []byte{']'}},
+			},
+		},
+		"two elements": {
+			[]Tokens{
+				TokensForTraversal(hcl.Traversal{
+					hcl.TraverseRoot{Name: "root"},
+					hcl.TraverseAttr{Name: "attr"},
+				}),
+				TokensForValue(cty.StringVal("foo")),
+			},
+			Tokens{
+				{Type: hclsyntax.TokenOBrack, Bytes: []byte{'['}},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("root")},
+				{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("attr")},
+				{Type: hclsyntax.TokenComma, Bytes: []byte{','}},
+				{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`), SpacesBefore: 1},
+				{Type: hclsyntax.TokenQuotedLit, Bytes: []byte("foo")},
+				{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenCBrack, Bytes: []byte{']'}},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := TokensForTuple(test.Val)
+
+			if !cmp.Equal(got, test.Want) {
+				diff := cmp.Diff(got, test.Want, cmp.Comparer(func(a, b []byte) bool {
+					return bytes.Equal(a, b)
+				}))
+				var gotBuf, wantBuf bytes.Buffer
+				got.WriteTo(&gotBuf)
+				test.Want.WriteTo(&wantBuf)
+				t.Errorf(
+					"wrong result\nvalue: %#v\ngot:   %s\nwant:  %s\ndiff:  %s",
+					test.Val, gotBuf.String(), wantBuf.String(), diff,
+				)
+			}
+		})
+	}
+}
+
+func TestTokensForObject(t *testing.T) {
+	tests := map[string]struct {
+		Val  []ObjectAttrTokens
+		Want Tokens
+	}{
+		"no attributes": {
+			nil,
+			Tokens{
+				{Type: hclsyntax.TokenOBrace, Bytes: []byte{'{'}},
+				{Type: hclsyntax.TokenCBrace, Bytes: []byte{'}'}},
+			},
+		},
+		"one attribute": {
+			[]ObjectAttrTokens{
+				{
+					Name: TokensForTraversal(hcl.Traversal{
+						hcl.TraverseRoot{Name: "bar"},
+					}),
+					Value: TokensForValue(cty.StringVal("baz")),
+				},
+			},
+			Tokens{
+				{Type: hclsyntax.TokenOBrace, Bytes: []byte{'{'}},
+				{Type: hclsyntax.TokenNewline, Bytes: []byte{'\n'}},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("bar"), SpacesBefore: 2},
+				{Type: hclsyntax.TokenEqual, Bytes: []byte{'='}, SpacesBefore: 1},
+				{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`), SpacesBefore: 1},
+				{Type: hclsyntax.TokenQuotedLit, Bytes: []byte("baz")},
+				{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenNewline, Bytes: []byte{'\n'}},
+				{Type: hclsyntax.TokenCBrace, Bytes: []byte{'}'}},
+			},
+		},
+		"two attributes": {
+			[]ObjectAttrTokens{
+				{
+					Name: TokensForTraversal(hcl.Traversal{
+						hcl.TraverseRoot{Name: "foo"},
+					}),
+					Value: TokensForTraversal(hcl.Traversal{
+						hcl.TraverseRoot{Name: "root"},
+						hcl.TraverseAttr{Name: "attr"},
+					}),
+				},
+				{
+					Name: TokensForTraversal(hcl.Traversal{
+						hcl.TraverseRoot{Name: "bar"},
+					}),
+					Value: TokensForValue(cty.StringVal("baz")),
+				},
+			},
+			Tokens{
+				{Type: hclsyntax.TokenOBrace, Bytes: []byte{'{'}},
+				{Type: hclsyntax.TokenNewline, Bytes: []byte{'\n'}},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("foo"), SpacesBefore: 2},
+				{Type: hclsyntax.TokenEqual, Bytes: []byte{'='}, SpacesBefore: 1},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("root"), SpacesBefore: 1},
+				{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("attr")},
+				{Type: hclsyntax.TokenNewline, Bytes: []byte{'\n'}},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("bar"), SpacesBefore: 2},
+				{Type: hclsyntax.TokenEqual, Bytes: []byte{'='}, SpacesBefore: 1},
+				{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`), SpacesBefore: 1},
+				{Type: hclsyntax.TokenQuotedLit, Bytes: []byte("baz")},
+				{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenNewline, Bytes: []byte{'\n'}},
+				{Type: hclsyntax.TokenCBrace, Bytes: []byte{'}'}},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := TokensForObject(test.Val)
+
+			if !cmp.Equal(got, test.Want) {
+				diff := cmp.Diff(got, test.Want, cmp.Comparer(func(a, b []byte) bool {
+					return bytes.Equal(a, b)
+				}))
+				var gotBuf, wantBuf bytes.Buffer
+				got.WriteTo(&gotBuf)
+				test.Want.WriteTo(&wantBuf)
+				t.Errorf(
+					"wrong result\nvalue: %#v\ngot:   %s\nwant:  %s\ndiff:  %s",
+					test.Val, gotBuf.String(), wantBuf.String(), diff,
+				)
+			}
+		})
+	}
+}
+
+func TestTokensForFunctionCall(t *testing.T) {
+	tests := map[string]struct {
+		FuncName string
+		Val      []Tokens
+		Want     Tokens
+	}{
+		"no arguments": {
+			"uuid",
+			nil,
+			Tokens{
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("uuid")},
+				{Type: hclsyntax.TokenOParen, Bytes: []byte{'('}},
+				{Type: hclsyntax.TokenCParen, Bytes: []byte(")")},
+			},
+		},
+		"one argument": {
+			"strlen",
+			[]Tokens{
+				TokensForValue(cty.StringVal("hello")),
+			},
+			Tokens{
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("strlen")},
+				{Type: hclsyntax.TokenOParen, Bytes: []byte{'('}},
+				{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenQuotedLit, Bytes: []byte("hello")},
+				{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenCParen, Bytes: []byte(")")},
+			},
+		},
+		"two arguments": {
+			"list",
+			[]Tokens{
+				TokensForIdentifier("string"),
+				TokensForIdentifier("int"),
+			},
+			Tokens{
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("list")},
+				{Type: hclsyntax.TokenOParen, Bytes: []byte{'('}},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("string")},
+				{Type: hclsyntax.TokenComma, Bytes: []byte(",")},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte("int"), SpacesBefore: 1},
+				{Type: hclsyntax.TokenCParen, Bytes: []byte(")")},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := TokensForFunctionCall(test.FuncName, test.Val...)
+
+			if !cmp.Equal(got, test.Want) {
+				diff := cmp.Diff(got, test.Want, cmp.Comparer(func(a, b []byte) bool {
+					return bytes.Equal(a, b)
+				}))
+				var gotBuf, wantBuf bytes.Buffer
+				got.WriteTo(&gotBuf)
+				test.Want.WriteTo(&wantBuf)
+				t.Errorf(
+					"wrong result\nvalue: %#v\ngot:   %s\nwant:  %s\ndiff:  %s",
+					test.Val, gotBuf.String(), wantBuf.String(), diff,
+				)
+			}
+		})
+	}
+}
+
+func TestTokenGenerateConsistency(t *testing.T) {
+
+	bytesComparer := cmp.Comparer(func(a, b []byte) bool {
+		return bytes.Equal(a, b)
+	})
+
+	// This test verifies that different ways of generating equivalent token
+	// sequences all generate identical tokens, to help us keep them all in
+	// sync under future maintanence.
+
+	t.Run("tuple constructor", func(t *testing.T) {
+		tests := map[string]struct {
+			elems []cty.Value
+		}{
+			"no elements": {
+				nil,
+			},
+			"one element": {
+				[]cty.Value{
+					cty.StringVal("hello"),
+				},
+			},
+			"two elements": {
+				[]cty.Value{
+					cty.StringVal("hello"),
+					cty.StringVal("world"),
+				},
+			},
+		}
+
+		for name, test := range tests {
+			t.Run(name, func(t *testing.T) {
+				var listVal cty.Value
+				if len(test.elems) > 0 {
+					listVal = cty.ListVal(test.elems)
+				} else {
+					listVal = cty.ListValEmpty(cty.DynamicPseudoType)
+				}
+				fromListValue := TokensForValue(listVal)
+				fromTupleValue := TokensForValue(cty.TupleVal(test.elems))
+				elemTokens := make([]Tokens, len(test.elems))
+				for i, v := range test.elems {
+					elemTokens[i] = TokensForValue(v)
+				}
+				fromTupleTokens := TokensForTuple(elemTokens)
+
+				if diff := cmp.Diff(fromListValue, fromTupleTokens, bytesComparer); diff != "" {
+					t.Errorf("inconsistency between TokensForValue(list) and TokensForTuple\n%s", diff)
+				}
+				if diff := cmp.Diff(fromTupleValue, fromTupleTokens, bytesComparer); diff != "" {
+					t.Errorf("inconsistency between TokensForValue(tuple) and TokensForTuple\n%s", diff)
+				}
+
+			})
+		}
+	})
+
+	t.Run("object constructor", func(t *testing.T) {
+		tests := map[string]struct {
+			attrs map[string]cty.Value
+		}{
+			"no elements": {
+				nil,
+			},
+			"one element": {
+				map[string]cty.Value{
+					"greeting": cty.StringVal("hello"),
+				},
+			},
+			"two elements": {
+				map[string]cty.Value{
+					"greeting1": cty.StringVal("hello"),
+					"greeting2": cty.StringVal("world"),
+				},
+			},
+		}
+
+		for name, test := range tests {
+			t.Run(name, func(t *testing.T) {
+				var mapVal cty.Value
+				if len(test.attrs) > 0 {
+					mapVal = cty.MapVal(test.attrs)
+				} else {
+					mapVal = cty.MapValEmpty(cty.DynamicPseudoType)
+				}
+				fromMapValue := TokensForValue(mapVal)
+				fromObjectValue := TokensForValue(cty.ObjectVal(test.attrs))
+				attrTokens := make([]ObjectAttrTokens, 0, len(test.attrs))
+				for k, v := range test.attrs {
+					attrTokens = append(attrTokens, ObjectAttrTokens{
+						Name:  TokensForIdentifier(k),
+						Value: TokensForValue(v),
+					})
+				}
+				fromObjectTokens := TokensForObject(attrTokens)
+
+				if diff := cmp.Diff(fromMapValue, fromObjectTokens, bytesComparer); diff != "" {
+					t.Errorf("inconsistency between TokensForValue(map) and TokensForObject\n%s", diff)
+				}
+				if diff := cmp.Diff(fromObjectValue, fromObjectTokens, bytesComparer); diff != "" {
+					t.Errorf("inconsistency between TokensForValue(object) and TokensForObject\n%s", diff)
+				}
+			})
+		}
+	})
+}

--- a/hclwrite/tokens.go
+++ b/hclwrite/tokens.go
@@ -114,6 +114,16 @@ func (ts Tokens) BuildTokens(to Tokens) Tokens {
 	return append(to, ts...)
 }
 
+// ObjectAttrTokens represents the raw tokens for the name and value of
+// one attribute in an object constructor expression.
+//
+// This is defined primarily for use with function TokensForObject. See
+// that function's documentation for more information.
+type ObjectAttrTokens struct {
+	Name  Tokens
+	Value Tokens
+}
+
 func newIdentToken(name string) *Token {
 	return &Token{
 		Type:  hclsyntax.TokenIdent,


### PR DESCRIPTION
Add several function for `SetAttributeRaw()` enhancement, which include ways transfer `Traverse` to `Tokens`

`TokensForListTraversal` support for list `traversal`, mentioned in #347 
struct like this
```golang
// block for
func main() {
	file := NewEmptyFile()
	body := file.Body()
	block := body.AppendNewBlock("resource", []string{"foo"})
	tokens := TokensForListTraversal([]hcl.Traversal{
		{
			hcl.TraverseRoot{Name: "root"},
			hcl.TraverseAttr{Name: "attr"},
		},
		{
			hcl.TraverseRoot{Name: "second"},
			hcl.TraverseAttr{Name: "attr"},
		},
	})
	block.Body().SetAttributeRaw("bar", tokens)
	fmt.Printf("%s", file.Bytes())
}
```
and got
```
resource "foo" {
  bar = [root.attr,second.attr]
}
```


`TokensForListTokens` for mixed `traversal` value and cty value,  trans all traversal and cty value into `Tokens` , then create a list.
struct like this
```golang
// block for
func main() {
	file := NewEmptyFile()
	body := file.Body()
	block := body.AppendNewBlock("resource", []string{"foo"})
	tokens := TokensForListTokens([]Tokens{
		TokensForTraversal(hcl.Traversal{
		hcl.TraverseRoot{Name: "root"},
		hcl.TraverseAttr{Name: "attr"},
		}),
		TokensForValue(cty.StringVal("baz")),
	})
	block.Body().SetAttributeRaw("bar", tokens)
	fmt.Printf("%s", file.Bytes())
}
```
and got
```
resource "foo" {
  bar = [root.attr,"baz"]
}
```

`TokensForObject` for nest struct of any value, including ctx value,`traversal`, list `traversal`,  even another object
```golang
// block for
func main() {
	file := NewEmptyFile()
	body := file.Body()
	block := body.AppendNewBlock("resource", []string{"foo"})
	tokens := TokensForObject(map[string]Tokens{
		"x": TokensForTraversal(hcl.Traversal{
			hcl.TraverseRoot{Name: "root"},
			hcl.TraverseAttr{Name: "attr"},
		}),
		"y": TokensForValue(cty.StringVal("abc")),
		"z": TokensForListTraversal([]hcl.Traversal{
			{
				hcl.TraverseRoot{Name: "env"},
				hcl.TraverseAttr{Name: "PATH"},
			},
		}),
	})
	block.Body().SetAttributeRaw("bar", tokens)
	fmt.Printf("%s", file.Bytes())
}
```
and got
```
resource "foo" {
  bar = {
    x = root.attr
    y = "abc"
    z = [env.Path]
  }
}
```
