### PR TITLE
hclwrite: Add RenameAttribute on Body

### DIFF
--- a/hclwrite/ast_attribute.go
+++ b/hclwrite/ast_attribute.go
@@ -50,8 +50,8 @@ func (a *Attribute) Expr() *Expression {
 	return a.expr.content.(*Expression)
 }
 
-// SetName updates the name of the attribute.
-func (a *Attribute) SetName(name string) {
+// setName updates the name of the attribute.
+func (a *Attribute) setName(name string) {
 	nameObj := newIdentifier(newIdentToken(name))
 	a.name = a.name.ReplaceWith(nameObj)
 }

--- a/hclwrite/ast_attribute.go
+++ b/hclwrite/ast_attribute.go
@@ -50,6 +50,7 @@ func (a *Attribute) Expr() *Expression {
 	return a.expr.content.(*Expression)
 }
 
+// SetName updates the name of the attribute.
 func (a *Attribute) SetName(name string) {
 	nameObj := newIdentifier(newIdentToken(name))
 	a.name = a.name.ReplaceWith(nameObj)

--- a/hclwrite/ast_attribute.go
+++ b/hclwrite/ast_attribute.go
@@ -49,3 +49,8 @@ func (a *Attribute) init(name string, expr *Expression) {
 func (a *Attribute) Expr() *Expression {
 	return a.expr.content.(*Expression)
 }
+
+func (a *Attribute) SetName(name string) {
+	nameObj := newIdentifier(newIdentToken(name))
+	a.name = a.name.ReplaceWith(nameObj)
+}

--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -103,6 +103,21 @@ func (b *Body) getAttributeNode(name string) *node {
 	return nil
 }
 
+// RenameAttribute changes the attribute named fromName to toName.
+// Takes no action if fromName is missing or there is already a
+// conflicting attribute called toName.
+//
+// Returns true if the rename succeeded.
+func (b *Body) RenameAttribute(fromName, toName string) bool {
+	attr := b.GetAttribute(fromName)
+	conflictingAttr := b.GetAttribute(toName)
+	if attr == nil || conflictingAttr != nil {
+		return false
+	}
+	attr.setName(toName)
+	return true
+}
+
 // FirstMatchingBlock returns a first matching block from the body that has the
 // given name and labels or returns nil if there is currently no matching
 // block.

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -1200,6 +1200,90 @@ func TestBodySetAttributeName(t *testing.T) {
 				},
 			},
 		},
+		{
+			"a = false\n",
+			"b",
+			"c",
+			Tokens{
+				{
+					Type:         hclsyntax.TokenIdent,
+					Bytes:        []byte{'a'},
+					SpacesBefore: 0,
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte{'='},
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenIdent,
+					Bytes:        []byte("false"),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNewline,
+					Bytes:        []byte{'\n'},
+					SpacesBefore: 0,
+				},
+				{
+					Type:         hclsyntax.TokenEOF,
+					Bytes:        []byte{},
+					SpacesBefore: 0,
+				},
+			},
+		},
+		{
+			"a = false\nb = false\n",
+			"a",
+			"b",
+			Tokens{
+				{
+					Type:         hclsyntax.TokenIdent,
+					Bytes:        []byte{'a'},
+					SpacesBefore: 0,
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte{'='},
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenIdent,
+					Bytes:        []byte("false"),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNewline,
+					Bytes:        []byte{'\n'},
+					SpacesBefore: 0,
+				},
+				{
+					Type:         hclsyntax.TokenIdent,
+					Bytes:        []byte{'b'},
+					SpacesBefore: 0,
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte{'='},
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenIdent,
+					Bytes:        []byte("false"),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNewline,
+					Bytes:        []byte{'\n'},
+					SpacesBefore: 0,
+				},
+				{
+					Type:         hclsyntax.TokenEOF,
+					Bytes:        []byte{},
+					SpacesBefore: 0,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1211,15 +1295,19 @@ func TestBodySetAttributeName(t *testing.T) {
 				}
 				t.Fatalf("unexpected diagnostics")
 			}
+			oldExists := nil != f.Body().GetAttribute(test.oldName)
+			newExists := nil != f.Body().GetAttribute(test.newName)
+			shouldSucceed := (oldExists && !newExists)
+			success := f.Body().RenameAttribute(test.oldName, test.newName)
 
-			if attr := f.Body().GetAttribute(test.oldName); attr != nil {
-				attr.SetName(test.newName)
-			}
 			got := f.BuildTokens(nil)
 			format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
+			}
+			if success != shouldSucceed {
+				t.Errorf("RenameAttribute returned %v when it should have returned %v ", success, shouldSucceed)
 			}
 		})
 	}

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -1149,6 +1149,82 @@ func TestBodyRemoveAttribute(t *testing.T) {
 	}
 }
 
+func TestBodySetAttributeName(t *testing.T) {
+	tests := []struct {
+		src     string
+		oldName string
+		newName string
+		want    Tokens
+	}{
+		{
+			"",
+			"a",
+			"b",
+			Tokens{
+				{
+					Type:         hclsyntax.TokenEOF,
+					Bytes:        []byte{},
+					SpacesBefore: 0,
+				},
+			},
+		},
+		{
+			"a = false\n",
+			"a",
+			"b",
+			Tokens{
+				{
+					Type:         hclsyntax.TokenIdent,
+					Bytes:        []byte{'b'},
+					SpacesBefore: 0,
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte{'='},
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenIdent,
+					Bytes:        []byte("false"),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNewline,
+					Bytes:        []byte{'\n'},
+					SpacesBefore: 0,
+				},
+				{
+					Type:         hclsyntax.TokenEOF,
+					Bytes:        []byte{},
+					SpacesBefore: 0,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s->%s in %s", test.oldName, test.newName, test.src), func(t *testing.T) {
+			f, diags := ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != 0 {
+				for _, diag := range diags {
+					t.Logf("- %s", diag.Error())
+				}
+				t.Fatalf("unexpected diagnostics")
+			}
+
+			if attr := f.Body().GetAttribute(test.oldName); attr != nil {
+				attr.SetName(test.newName)
+			}
+			got := f.BuildTokens(nil)
+			format(got)
+			if !reflect.DeepEqual(got, test.want) {
+				diff := cmp.Diff(test.want, got)
+				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
+			}
+		})
+	}
+}
+
 func TestBodyAppendBlock(t *testing.T) {
 	tests := []struct {
 		src       string

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -1149,7 +1149,7 @@ func TestBodyRemoveAttribute(t *testing.T) {
 	}
 }
 
-func TestBodySetAttributeName(t *testing.T) {
+func TestBodyRenameAttribute(t *testing.T) {
 	tests := []struct {
 		src     string
 		oldName string


### PR DESCRIPTION
Adding the ability to change the name of an attribute already set on a block body. This can be used to automate renaming of terraform `locals`.

Without this, the only obvious approach is to remove the current attribute and add a new one, but this loses the order and comments which isn't desirable.

## Usage

```
attr := block.Body().GetAttribute(fromName)
if attr != nil {
  attr.SetName(toName)
}
```

*UPDATE*

```
wasChanged := block.Body().RenameAttribute(fromName, toName)
```