### PR TITLE
Diagnostics.Append: can now take varargs & skips nil diags

### DIFF
--- a/diagnostic.go
+++ b/diagnostic.go
@@ -91,14 +91,14 @@ func (d Diagnostics) Error() string {
 	}
 }
 
-// Append appends a new error to a Diagnostics and return the whole Diagnostics.
+// Append appends new errors to a Diagnostics and returns the whole Diagnostics.
 //
-// This is provided as a convenience for returning from a function that
-// collects and then returns a set of diagnostics:
+// This is provided as a convenience for returning from a function that collects
+// and then returns a set of diagnostics:
 //
 //     return nil, diags.Append(&hcl.Diagnostic{ ... })
 //
-// Note that this modifies the array underlying the diagnostics slice, so
+// Note that this returns a new slice which might reference the original one, so
 // must be used carefully within a single codepath. It is incorrect (and rude)
 // to extend a diagnostics created by a different subsystem.
 func (d Diagnostics) Append(diags ...*Diagnostic) Diagnostics {

--- a/diagnostic.go
+++ b/diagnostic.go
@@ -101,8 +101,14 @@ func (d Diagnostics) Error() string {
 // Note that this modifies the array underlying the diagnostics slice, so
 // must be used carefully within a single codepath. It is incorrect (and rude)
 // to extend a diagnostics created by a different subsystem.
-func (d Diagnostics) Append(diag *Diagnostic) Diagnostics {
-	return append(d, diag)
+func (d Diagnostics) Append(diags ...*Diagnostic) Diagnostics {
+	for _, diag := range diags {
+		if diag == nil {
+			continue
+		}
+		d = append(d, diag)
+	}
+	return d
 }
 
 // Extend concatenates the given Diagnostics with the receiver and returns


### PR DESCRIPTION
👋🏼  Thought this would be a nice — non-breaking change — to have. Let me know what you think 🙂 .

Note that there is that comment `Note that this modifies the array underlying the diagnostics slice` which I'm pretty sure is not true.
To my understanding, this would return a new slice.