### PR TITLE
hclwrite: fix data race in formatSpaces()

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Go test
         run: |
-          go test ./...
+          go test ./... -race
 
   fmt_and_vet:
     name: "fmt and lint"

--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -4,16 +4,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
-var inKeyword = hclsyntax.Keyword([]byte{'i', 'n'})
-
-// placeholder token used when we don't have a token but we don't want
-// to pass a real "nil" and complicate things with nil pointer checks
-var nilToken = &Token{
-	Type:         hclsyntax.TokenNil,
-	Bytes:        []byte{},
-	SpacesBefore: 0,
-}
-
 // format rewrites tokens within the given sequence, in-place, to adjust the
 // whitespace around their content to achieve canonical formatting.
 func format(tokens Tokens) {
@@ -108,6 +98,14 @@ func formatIndent(lines []formatLine) {
 }
 
 func formatSpaces(lines []formatLine) {
+	// placeholder token used when we don't have a token but we don't want
+	// to pass a real "nil" and complicate things with nil pointer checks
+	nilToken := &Token{
+		Type:         hclsyntax.TokenNil,
+		Bytes:        []byte{},
+		SpacesBefore: 0,
+	}
+
 	for _, line := range lines {
 		for i, token := range line.lead {
 			var before, after *Token
@@ -156,7 +154,6 @@ func formatSpaces(lines []formatLine) {
 }
 
 func formatCells(lines []formatLine) {
-
 	chainStart := -1
 	maxColumns := 0
 
@@ -218,7 +215,6 @@ func formatCells(lines []formatLine) {
 	if chainStart != -1 {
 		closeCommentChain(len(lines))
 	}
-
 }
 
 // spaceAfterToken decides whether a particular subject token should have a
@@ -251,7 +247,7 @@ func spaceAfterToken(subject, before, after *Token) bool {
 		// No extra spaces within templates
 		return false
 
-	case inKeyword.TokenMatches(subject.asHCLSyntax()) && before.Type == hclsyntax.TokenIdent:
+	case hclsyntax.Keyword([]byte{'i', 'n'}).TokenMatches(subject.asHCLSyntax()) && before.Type == hclsyntax.TokenIdent:
 		// This is a special case for inside for expressions where a user
 		// might want to use a literal tuple constructor:
 		// [for x in [foo]: x]

--- a/hclwrite/round_trip_test.go
+++ b/hclwrite/round_trip_test.go
@@ -72,7 +72,7 @@ block {
 			if !bytes.Equal(result, src) {
 				dmp := diffmatchpatch.New()
 				diffs := dmp.DiffMain(string(src), string(result), false)
-				//t.Errorf("wrong result\nresult:\n%s\ninput:\n%s", result, src)
+				// t.Errorf("wrong result\nresult:\n%s\ninput:\n%s", result, src)
 				t.Errorf("wrong result\ndiff: (red indicates missing lines, and green indicates unexpected lines)\n%s", dmp.DiffPrettyText(diffs))
 			}
 		})
@@ -124,7 +124,6 @@ func TestRoundTripFormat(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test, func(t *testing.T) {
-
 			attrsAsObj := func(src []byte, phase string) cty.Value {
 				t.Logf("source %s:\n%s", phase, src)
 				f, diags := hclsyntax.ParseConfig(src, "", hcl.Pos{Line: 1, Column: 1})
@@ -168,5 +167,16 @@ func TestRoundTripFormat(t *testing.T) {
 			}
 		})
 	}
+}
 
+// TestRoundTripSafeConcurrent concurrently generates a new file. When run with
+// the race detector it will fail if a data race is detected.
+func TestRoundTripSafeConcurrent(t *testing.T) {
+	for i := 0; i < 2; i++ {
+		go func() {
+			f := NewEmptyFile()
+			b := f.Body()
+			b.SetAttributeValue("foo", cty.StringVal("bar"))
+		}()
+	}
 }


### PR DESCRIPTION
This fixes a data race in `formatSpaces()` by inlining shared state into the caller.

Before
```go test ./hclwrite/... -race
==================
WARNING: DATA RACE
Write at 0x0000017bf900 by goroutine 14:
  github.com/hashicorp/hcl/v2/hclwrite.formatSpaces()
      /Users/ryan/code/hashi/hcl/hclwrite/format.go:127 +0x29d
  github.com/hashicorp/hcl/v2/hclwrite.format()
      /Users/ryan/code/hashi/hcl/hclwrite/format.go:36 +0x6c
  github.com/hashicorp/hcl/v2/hclwrite.TokensForValue()
      /Users/ryan/code/hashi/hcl/hclwrite/generate.go:25 +0x8a
  github.com/hashicorp/hcl/v2/hclwrite.NewExpressionLiteral()
      /Users/ryan/code/hashi/hcl/hclwrite/ast_expression.go:61 +0x97
  github.com/hashicorp/hcl/v2/hclwrite.(*Body).SetAttributeValue()
      /Users/ryan/code/hashi/hcl/hclwrite/ast_body.go:167 +0xd4
  github.com/hashicorp/hcl/v2/hclwrite.TestRoundTripSafeConcurrent.func1()
      /Users/ryan/code/hashi/hcl/hclwrite/round_trip_test.go:179 +0xee

Previous write at 0x0000017bf900 by goroutine 35:
  github.com/hashicorp/hcl/v2/hclwrite.formatSpaces()
      /Users/ryan/code/hashi/hcl/hclwrite/format.go:127 +0x29d
  github.com/hashicorp/hcl/v2/hclwrite.format()
      /Users/ryan/code/hashi/hcl/hclwrite/format.go:36 +0x6c
  github.com/hashicorp/hcl/v2/hclwrite.TokensForValue()
      /Users/ryan/code/hashi/hcl/hclwrite/generate.go:25 +0x8a
  github.com/hashicorp/hcl/v2/hclwrite.NewExpressionLiteral()
      /Users/ryan/code/hashi/hcl/hclwrite/ast_expression.go:61 +0x97
  github.com/hashicorp/hcl/v2/hclwrite.(*Body).SetAttributeValue()
      /Users/ryan/code/hashi/hcl/hclwrite/ast_body.go:167 +0xd4
  github.com/hashicorp/hcl/v2/hclwrite.TestRoundTripSafeConcurrent.func1()
      /Users/ryan/code/hashi/hcl/hclwrite/round_trip_test.go:179 +0xee

Goroutine 14 (running) created at:
  github.com/hashicorp/hcl/v2/hclwrite.TestRoundTripSafeConcurrent()
      /Users/ryan/code/hashi/hcl/hclwrite/round_trip_test.go:176 +0x34
  testing.tRunner()
      /usr/local/Cellar/go/1.17.6/libexec/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/Cellar/go/1.17.6/libexec/src/testing/testing.go:1306 +0x47

Goroutine 35 (finished) created at:
  github.com/hashicorp/hcl/v2/hclwrite.TestRoundTripSafeConcurrent()
      /Users/ryan/code/hashi/hcl/hclwrite/round_trip_test.go:176 +0x34
  testing.tRunner()
      /usr/local/Cellar/go/1.17.6/libexec/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/Cellar/go/1.17.6/libexec/src/testing/testing.go:1306 +0x47
==================
FAIL
FAIL    github.com/hashicorp/hcl/v2/hclwrite    0.690s
?       github.com/hashicorp/hcl/v2/hclwrite/fuzz/config        [no test files]
FAIL
```

My apologies for the messy diff, my editor runs `gofumpt` and `yamllint` so that's where the noise is coming from. If it's a problem let me know and I'll update it.

Signed-off-by: Ryan Cragun <me@ryan.ec>