### PR TITLE
Allows assigning labels to custom types having string as underlying type

### DIFF
--- a/gohcl/decode.go
+++ b/gohcl/decode.go
@@ -264,7 +264,17 @@ func decodeBlockToValue(block *hcl.Block, ctx *hcl.EvalContext, v reflect.Value)
 		blockTags := getFieldTags(v.Type())
 		for li, lv := range block.Labels {
 			lfieldIdx := blockTags.Labels[li].FieldIndex
-			v.Field(lfieldIdx).Set(reflect.ValueOf(lv))
+			field := v.Field(lfieldIdx)
+			fieldType := field.Type()
+			val := reflect.ValueOf(lv)
+			valType := val.Type()
+			if !valType.AssignableTo(fieldType) {
+				// allows assigning labels to custom types having string as underlying type
+				if valType.ConvertibleTo(fieldType) {
+					val = val.Convert(fieldType)
+				}
+			}
+			field.Set(val)
 		}
 	}
 

--- a/gohcl/decode_test.go
+++ b/gohcl/decode_test.go
@@ -41,6 +41,11 @@ func TestDecodeBody(t *testing.T) {
 		Nested []withTwoAttributes `hcl:"nested,block"`
 	}
 
+	type Custom string
+	type withCustomAttribute struct {
+		Custom `hcl:"custom,optional"`
+	}
+
 	tests := []struct {
 		Body      map[string]interface{}
 		Target    func() interface{}
@@ -446,6 +451,62 @@ func TestDecodeBody(t *testing.T) {
 				return noodle.Name == "foo_foo"
 			},
 			0,
+		},
+		{
+			map[string]interface{}{
+				"noodle": map[string]interface{}{
+					"foo_foo": map[string]interface{}{},
+				},
+			},
+			makeInstantiateType(struct {
+				Noodle struct {
+					Custom `hcl:"name,label"`
+				} `hcl:"noodle,block"`
+			}{}),
+			func(gotI interface{}) bool {
+				noodle := gotI.(struct {
+					Noodle struct {
+						Custom `hcl:"name,label"`
+					} `hcl:"noodle,block"`
+				}).Noodle
+				return noodle.Custom == "foo_foo"
+			},
+			0,
+		},
+		{
+			map[string]interface{}{
+				"noodle": map[string]interface{}{
+					"foo_foo": map[string]interface{}{},
+				},
+			},
+			makeInstantiateType(struct {
+				Noodle struct {
+					Name Custom `hcl:"name,label"`
+				} `hcl:"noodle,block"`
+			}{}),
+			func(gotI interface{}) bool {
+				noodle := gotI.(struct {
+					Noodle struct {
+						Name Custom `hcl:"name,label"`
+					} `hcl:"noodle,block"`
+				}).Noodle
+				return noodle.Name == "foo_foo"
+			},
+			0,
+		},
+		{
+			Body: map[string]interface{}{
+				"custom": "foo",
+			},
+			Target:    makeInstantiateType(withCustomAttribute{}),
+			DiagCount: 0,
+			Check: func(v interface{}) bool {
+				val, ok := v.(withCustomAttribute)
+				if !ok {
+					return false
+				}
+				return val.Custom == "foo"
+			},
 		},
 		{
 			map[string]interface{}{


### PR DESCRIPTION
Given a body using a label from a custom type that has `string` as underlying type:

```go
type Custom string
type Body struct {
    Block struct {
        Name Custom `hcl:"name,label"`
    } `hcl:"block,block"`
}
```

The following HCL would fail due to a reflection error: 

```hcl
block "foo" {}
```

```
Error: reflect.Set: value of type string is not assignable to type gohcl.Custom
```

With the patch in this PR, this operation is now accepted and the `Name` field would get the `foo` label value.