### PR TITLE
Implement HEREDOC generation in hclwrite

### DIFF
--- a/hclwrite/generate.go
+++ b/hclwrite/generate.go
@@ -2,6 +2,7 @@ package hclwrite
 
 import (
 	"fmt"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -212,23 +213,40 @@ func appendTokensForValue(val cty.Value, toks Tokens) Tokens {
 		})
 
 	case val.Type() == cty.String:
-		// TODO: If it's a multi-line string ending in a newline, format
-		// it as a HEREDOC instead.
-		src := escapeQuotedStringLit(val.AsString())
-		toks = append(toks, &Token{
-			Type:  hclsyntax.TokenOQuote,
-			Bytes: []byte{'"'},
-		})
-		if len(src) > 0 {
+		if strings.HasSuffix(val.AsString(), "\n") {
+			toks = append(toks, &Token{
+				Type:  hclsyntax.TokenOHeredoc,
+				Bytes: []byte("<<EOH\n"),
+			})
 			toks = append(toks, &Token{
 				Type:  hclsyntax.TokenQuotedLit,
-				Bytes: src,
+				Bytes: []byte(val.AsString()),
+			})
+			toks = append(toks, &Token{
+				Type:  hclsyntax.TokenOHeredoc,
+				Bytes: []byte("EOH"),
+			})
+			toks = append(toks, &Token{
+				Type:  hclsyntax.TokenNewline,
+				Bytes: []byte{'\n'},
+			})
+		} else {
+			src := escapeQuotedStringLit(val.AsString())
+			toks = append(toks, &Token{
+				Type:  hclsyntax.TokenOQuote,
+				Bytes: []byte{'"'},
+			})
+			if len(src) > 0 {
+				toks = append(toks, &Token{
+					Type:  hclsyntax.TokenQuotedLit,
+					Bytes: src,
+				})
+			}
+			toks = append(toks, &Token{
+				Type:  hclsyntax.TokenCQuote,
+				Bytes: []byte{'"'},
 			})
 		}
-		toks = append(toks, &Token{
-			Type:  hclsyntax.TokenCQuote,
-			Bytes: []byte{'"'},
-		})
 
 	case val.Type().IsListType() || val.Type().IsSetType() || val.Type().IsTupleType():
 		toks = append(toks, &Token{

--- a/hclwrite/generate_test.go
+++ b/hclwrite/generate_test.go
@@ -122,16 +122,20 @@ func TestTokensForValue(t *testing.T) {
 			cty.StringVal("hello\nworld\n"),
 			Tokens{
 				{
-					Type:  hclsyntax.TokenOQuote,
-					Bytes: []byte(`"`),
+					Type:  hclsyntax.TokenOHeredoc,
+					Bytes: []byte("<<EOH\n"),
 				},
 				{
 					Type:  hclsyntax.TokenQuotedLit,
-					Bytes: []byte(`hello\nworld\n`),
+					Bytes: []byte("hello\nworld\n"),
 				},
 				{
-					Type:  hclsyntax.TokenCQuote,
-					Bytes: []byte(`"`),
+					Type:  hclsyntax.TokenOHeredoc,
+					Bytes: []byte("EOH"),
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
 				},
 			},
 		},
@@ -139,16 +143,20 @@ func TestTokensForValue(t *testing.T) {
 			cty.StringVal("hello\r\nworld\r\n"),
 			Tokens{
 				{
-					Type:  hclsyntax.TokenOQuote,
-					Bytes: []byte(`"`),
+					Type:  hclsyntax.TokenOHeredoc,
+					Bytes: []byte("<<EOH\n"),
 				},
 				{
 					Type:  hclsyntax.TokenQuotedLit,
-					Bytes: []byte(`hello\r\nworld\r\n`),
+					Bytes: []byte("hello\r\nworld\r\n"),
 				},
 				{
-					Type:  hclsyntax.TokenCQuote,
-					Bytes: []byte(`"`),
+					Type:  hclsyntax.TokenOHeredoc,
+					Bytes: []byte("EOH"),
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
 				},
 			},
 		},


### PR DESCRIPTION
Currently, the hclwrite generator has a TODO on rendering HEREDOC. This patch will format multi-line string ending in a newline as a HEREDOC instead.