### PR TITLE
Update spec.md to avoid suggesting ! is a binary operator

### DIFF
--- a/hclsyntax/spec.md
+++ b/hclsyntax/spec.md
@@ -635,7 +635,7 @@ binaryOp = ExprTerm binaryOperator ExprTerm;
 binaryOperator = compareOperator | arithmeticOperator | logicOperator;
 compareOperator = "==" | "!=" | "<" | ">" | "<=" | ">=";
 arithmeticOperator = "+" | "-" | "*" | "/" | "%";
-logicOperator = "&&" | "||" | "!";
+logicOperator = "&&" | "||";
 ```
 
 The unary operators have the highest precedence.


### PR DESCRIPTION
The current spec appears to suggest that the bang is a binary operator, which would enable
expressions such as `foo ! bar`.

https://github.com/hashicorp/hcl/blob/main/hclsyntax/parser.go#L1070 seems to suggest this is only
a unary operator.