### PR TITLE
Object elements can be separated by comma or newline

### DIFF
--- a/hclsyntax/spec.md
+++ b/hclsyntax/spec.md
@@ -268,7 +268,7 @@ collection value.
 ```ebnf
 CollectionValue = tuple | object;
 tuple = "[" (
-    (Expression ("," Expression)* ","?)?
+    (Expression (("," | Newline) Expression)* ","?)?
 ) "]";
 object = "{" (
     (objectelem (( "," | Newline) objectelem)* ","?)?

--- a/hclsyntax/spec.md
+++ b/hclsyntax/spec.md
@@ -271,7 +271,7 @@ tuple = "[" (
     (Expression ("," Expression)* ","?)?
 ) "]";
 object = "{" (
-    (objectelem ("," objectelem)* ","?)?
+    (objectelem (( "," | Newline) objectelem)* ","?)?
 ) "}";
 objectelem = (Identifier | Expression) ("=" | ":") Expression;
 ```


### PR DESCRIPTION
Hi!

According to

  https://developer.hashicorp.com/terraform/language/expressions/types#maps-objects

"Key/value pairs can be separated by either a comma or a line break."

But, the documentation here indicates that they may only be separated by a comma.

This is a little change to the docs to include the possibility of separating object elements by a line break.

thanks
Brian
