### PR TITLE
Implement gohcl.EvalContext

### DIFF
--- a/gohcl/eval_context.go
+++ b/gohcl/eval_context.go
@@ -1,0 +1,94 @@
+package gohcl
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"reflect"
+)
+
+func EvalContext(v interface{}) *hcl.EvalContext {
+	return &hcl.EvalContext{
+		Variables: structMapVal(v),
+	}
+}
+
+func structMapVal(v interface{}) map[string]cty.Value {
+	rt := reflect.TypeOf(v)
+	rv := reflect.ValueOf(v)
+
+	if rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+
+	var variables = make(map[string]cty.Value)
+
+	for index := 0; index < rt.NumField(); index++ {
+		key := rt.Field(index)
+		value := rv.Field(index)
+
+		if !value.IsZero() {
+			k := marshalKey(key.Name)
+			//k := key.Name
+			variables[k] = reflectVal(value)
+		}
+
+	}
+	return variables
+
+}
+
+func reflectVal(v reflect.Value) cty.Value {
+	switch v.Kind() {
+	case reflect.Int:
+		return cty.NumberIntVal(v.Int())
+	case reflect.String:
+		return cty.StringVal(v.String())
+	case reflect.Struct:
+		return structVal(v)
+	case reflect.Slice:
+		return sliceVal(v)
+	default:
+		panic(fmt.Sprintf("target value must be pointer to int, string, slice, struct or map, not %s", v.String()))
+	}
+}
+
+func sliceVal(v reflect.Value) cty.Value {
+	elems := []cty.Value{}
+	for i := 0; i < v.Len(); i++ {
+		elems = append(elems, reflectVal(v.Index(i)))
+	}
+	return cty.TupleVal(elems)
+}
+
+func structVal(v reflect.Value) cty.Value {
+	var ctyVals = make(map[string]cty.Value)
+	for index := 0; index < v.Type().NumField(); index++ {
+		key := v.Type().Field(index)
+		value := v.Field(index)
+		ctyVals[marshalKey(key.Name)] = reflectVal(value)
+	}
+	return cty.MapVal(ctyVals)
+}
+
+func marshalKey(input string) string {
+	if input == "" {
+		return ""
+	}
+	var output bytes.Buffer
+	for index, letter := range input {
+		if letter < 96 {
+			letter = letter + 32
+			if index > 0 {
+				output.WriteString("_")
+			}
+
+		}
+		output.WriteRune(letter)
+	}
+	return output.String()
+}

--- a/gohcl/eval_context.go
+++ b/gohcl/eval_context.go
@@ -43,7 +43,10 @@ func structMapVal(v interface{}) map[string]cty.Value {
 
 		if !value.IsZero() {
 			k := marshalKey(key.Name)
-			variables[k] = reflectVal(value)
+			refVal, err := reflectVal(value)
+			if err == nil {
+				variables[k] = refVal
+			}
 		}
 
 	}
@@ -54,48 +57,81 @@ func structMapVal(v interface{}) map[string]cty.Value {
 // reflectVal receive a reflect.Value and according to the kind implemented,
 // return a cty.Value. The value kind that have been implemented so far are
 // Int/Uint, Float, String, and nest Struct and Slice
-func reflectVal(v reflect.Value) cty.Value {
+func reflectVal(v reflect.Value) (cty.Value, error) {
 	switch v.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return cty.NumberIntVal(v.Int())
+		return cty.NumberIntVal(v.Int()), nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return cty.NumberUIntVal(v.Uint())
+		return cty.NumberUIntVal(v.Uint()), nil
 	case reflect.Float32, reflect.Float64:
-		return cty.NumberFloatVal(v.Float())
+		return cty.NumberFloatVal(v.Float()), nil
 	case reflect.String:
-		return cty.StringVal(v.String())
+		return cty.StringVal(v.String()), nil
 	case reflect.Struct:
 		return structVal(v)
 	case reflect.Slice:
-		return sliceVal(v)
+		return listVal(v)
+	case reflect.Map:
+		return mapVal(v)
 	default:
-		panic(fmt.Sprintf("target value must be pointer to int, string, slice, struct or map, not %s", v.String()))
+		return cty.EmptyObjectVal, fmt.Errorf("target value must be pointer to number, string, slice, struct or map, not %s", v.String())
 	}
 }
 
-// sliceVal receive a reflect.Value which should be asserted as Slice type.
+func mapVal(v reflect.Value) (cty.Value, error) {
+	var mapVar = make(map[string]cty.Value)
+	kind := v.Type().Key().Kind()
+	if kind == reflect.String {
+		iter := v.MapRange()
+		for iter.Next() {
+			refVal, err := reflectVal(iter.Value())
+			if err == nil {
+				mapVar[marshalKey(iter.Key().String())] = refVal
+			}
+		}
+		if len(mapVar) > 0 {
+			return cty.MapVal(mapVar), nil
+		}
+		return cty.EmptyObjectVal, fmt.Errorf("target map error or is empty")
+	}
+	return cty.EmptyObjectVal, fmt.Errorf("target key should be string, %s is not support", kind.String())
+}
+
+// listVal receive a reflect.Value which should be asserted as Slice type.
 // In the for loop, each var would be called by func reflectVal to return
 // a cty.Value and add into a slice.Finally return cty.ListVal
-func sliceVal(v reflect.Value) cty.Value {
+func listVal(v reflect.Value) (cty.Value, error) {
 	elems := []cty.Value{}
 	for i := 0; i < v.Len(); i++ {
-		elems = append(elems, reflectVal(v.Index(i)))
+		refVal, err := reflectVal(v.Index(i))
+		if err == nil {
+			elems = append(elems, refVal)
+		}
 	}
-	return cty.ListVal(elems)
+	if len(elems) > 0 {
+		return cty.ListVal(elems), nil
+	}
+	return cty.EmptyTupleVal, fmt.Errorf(" slice is empty, cty.ListVal must not call ListVal with empty slice")
 }
 
 // structVal received a reflect.Value which should be asserted as Struct type.
 // It uses the NumFiled() of  reflect type to loop all struct fields,
 // and return cty.MapVal
 
-func structVal(v reflect.Value) cty.Value {
+func structVal(v reflect.Value) (cty.Value, error) {
 	var ctyVals = make(map[string]cty.Value)
 	for index := 0; index < v.Type().NumField(); index++ {
 		key := v.Type().Field(index)
 		value := v.Field(index)
-		ctyVals[marshalKey(key.Name)] = reflectVal(value)
+		refVal, err := reflectVal(value)
+		if err == nil {
+			ctyVals[marshalKey(key.Name)] = refVal
+		}
 	}
-	return cty.MapVal(ctyVals)
+	if len(ctyVals) > 0 {
+		return cty.MapVal(ctyVals), nil
+	}
+	return cty.EmptyObjectVal, fmt.Errorf(" slice is empty, cty.ListVal must not call ListVal with empty map")
 }
 
 // marshalKey trans camelcase to lowercase with separated by underscores

--- a/gohcl/eval_context_test.go
+++ b/gohcl/eval_context_test.go
@@ -67,6 +67,52 @@ func TestEvalContext(t *testing.T) {
 				},
 			},
 		},
+		{
+			Input: struct {
+				HashMap map[string]string
+			}{
+				HashMap: map[string]string{
+					"a": "b",
+					"c": "d",
+				},
+			},
+			Output: hcl.EvalContext{Variables: map[string]cty.Value{
+				"hash_map": cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("b"),
+					"c": cty.StringVal("d"),
+				}),
+			}},
+		},
+		{
+			Input: struct {
+				HashMap map[string]string
+			}{
+				HashMap: map[string]string{},
+			},
+			Output: hcl.EvalContext{Variables: map[string]cty.Value{}},
+		},
+		{
+			Input: struct {
+				Array []string
+			}{
+				Array: []string{"elem-1", "elem-2"},
+			},
+			Output: hcl.EvalContext{Variables: map[string]cty.Value{
+				"array": cty.ListVal(
+					[]cty.Value{
+						cty.StringVal("elem-1"),
+						cty.StringVal("elem-2"),
+					}),
+			}},
+		},
+		{
+			Input: struct {
+				Array []string
+			}{
+				Array: []string{},
+			},
+			Output: hcl.EvalContext{Variables: map[string]cty.Value{}},
+		},
 	}
 
 	for index, test := range tests {

--- a/gohcl/eval_context_test.go
+++ b/gohcl/eval_context_test.go
@@ -57,7 +57,7 @@ func TestEvalContext(t *testing.T) {
 			Output: hcl.EvalContext{
 				Variables: map[string]cty.Value{
 					"i_o_mode": cty.StringVal("fake-mode"),
-					"services": cty.TupleVal([]cty.Value{
+					"services": cty.ListVal([]cty.Value{
 						cty.MapVal(map[string]cty.Value{
 							"type":        cty.StringVal("t"),
 							"name":        cty.StringVal("n"),

--- a/gohcl/eval_context_test.go
+++ b/gohcl/eval_context_test.go
@@ -1,0 +1,91 @@
+package gohcl
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"testing"
+)
+
+var (
+	valueComparer = cmp.Comparer(cty.Value.RawEquals)
+)
+
+func TestEvalContext(t *testing.T) {
+
+	type ServiceConfig struct {
+		Type       string `hcl:"type,label"`
+		Name       string `hcl:"name,label"`
+		ListenAddr string `hcl:"listen_addr"`
+	}
+	type Config struct {
+		IOMode   string          `hcl:"io_mode"`
+		Services []ServiceConfig `hcl:"service,block"`
+	}
+
+	type Context struct {
+		Pid string
+	}
+
+	tests := []struct {
+		Input  interface{}
+		Output hcl.EvalContext
+	}{
+		{
+			Input: &Context{
+				Pid: "fake-pid",
+			},
+			Output: hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"pid": cty.StringVal("fake-pid"),
+				},
+			},
+		},
+		{
+			Input: &Config{
+				IOMode: "fake-mode",
+				Services: []ServiceConfig{
+					{
+						Type:       "t",
+						Name:       "n",
+						ListenAddr: "addr",
+					},
+				},
+			},
+			Output: hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"i_o_mode": cty.StringVal("fake-mode"),
+					"services": cty.TupleVal([]cty.Value{
+						cty.MapVal(map[string]cty.Value{
+							"type":        cty.StringVal("t"),
+							"name":        cty.StringVal("n"),
+							"listen_addr": cty.StringVal("addr"),
+						}),
+					}),
+				},
+			},
+		},
+	}
+
+	for index, test := range tests {
+		t.Run(fmt.Sprintf("test-%d", index), func(t *testing.T) {
+			realOutput := EvalContext(test.Input)
+
+			gotVal := realOutput.Variables
+			wantVal := test.Output.Variables
+
+			if !cmp.Equal(gotVal, wantVal, valueComparer) {
+				diff := cmp.Diff(gotVal, wantVal, cmp.Comparer(func(a, b []byte) bool {
+					return bytes.Equal(a, b)
+				}))
+				t.Errorf(
+					"wrong result\nvalue: %#v\ngot:   %#v\nwant:  %#v\ndiff:  %s",
+					test.Input, gotVal, wantVal, diff,
+				)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Implement `gohcl.EvalContext` function, which should be implemented as doc as well.

1. Simple implementation from struct to `EvalContext.Variables` .
2. Cause of Functions are hardcoded, it might could convert .
3. Ignore empty object to cty.Value ( cty.ListVal or cty.MapVal with empty var might casue error)

More discuss on #565 