### PR TITLE
hclfmt: avoid rewrites when there are no changes in a file

### DIFF
--- a/cmd/hclfmt/main.go
+++ b/cmd/hclfmt/main.go
@@ -106,6 +106,7 @@ func processFiles() error {
 
 func processFile(fn string, in *os.File) error {
 	var err error
+	var hasLocalChanges bool = false
 	if in == nil {
 		in, err = os.Open(fn)
 		if err != nil {
@@ -131,10 +132,15 @@ func processFile(fn string, in *os.File) error {
 
 	if !bytes.Equal(inSrc, outSrc) {
 		changed = append(changed, fn)
+		hasLocalChanges = true
 	}
 
 	if *overwrite {
-		return ioutil.WriteFile(fn, outSrc, 0644)
+		if hasLocalChanges {
+			return ioutil.WriteFile(fn, outSrc, 0644)
+		} else {
+			return nil
+		}
 	}
 
 	_, err = os.Stdout.Write(outSrc)


### PR DESCRIPTION
 this is faster for large trees and also helps to make tools like            
 [treefmt](https://github.com/numtide/treefmt) to work, since it does not    
 update the mtime of the file.                                               