### PR TITLE
Meld consecutive template string literals

### DIFF
--- a/hclsyntax/parser_test.go
+++ b/hclsyntax/parser_test.go
@@ -738,26 +738,10 @@ block "valid" {}
 						Expr: &TemplateExpr{
 							Parts: []Expression{
 								&LiteralValueExpr{
-									Val: cty.StringVal("hello "),
+									Val: cty.StringVal("hello ${true}"),
 
 									SrcRange: hcl.Range{
 										Start: hcl.Pos{Line: 1, Column: 6, Byte: 5},
-										End:   hcl.Pos{Line: 1, Column: 12, Byte: 11},
-									},
-								},
-								&LiteralValueExpr{
-									Val: cty.StringVal("${"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 12, Byte: 11},
-										End:   hcl.Pos{Line: 1, Column: 15, Byte: 14},
-									},
-								},
-								&LiteralValueExpr{
-									Val: cty.StringVal("true}"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 15, Byte: 14},
 										End:   hcl.Pos{Line: 1, Column: 20, Byte: 19},
 									},
 								},
@@ -804,26 +788,10 @@ block "valid" {}
 						Expr: &TemplateExpr{
 							Parts: []Expression{
 								&LiteralValueExpr{
-									Val: cty.StringVal("hello "),
+									Val: cty.StringVal("hello %{true}"),
 
 									SrcRange: hcl.Range{
 										Start: hcl.Pos{Line: 1, Column: 6, Byte: 5},
-										End:   hcl.Pos{Line: 1, Column: 12, Byte: 11},
-									},
-								},
-								&LiteralValueExpr{
-									Val: cty.StringVal("%{"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 12, Byte: 11},
-										End:   hcl.Pos{Line: 1, Column: 15, Byte: 14},
-									},
-								},
-								&LiteralValueExpr{
-									Val: cty.StringVal("true}"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 15, Byte: 14},
 										End:   hcl.Pos{Line: 1, Column: 20, Byte: 19},
 									},
 								},
@@ -870,29 +838,10 @@ block "valid" {}
 						Expr: &TemplateExpr{
 							Parts: []Expression{
 								&LiteralValueExpr{
-									Val: cty.StringVal("hello "),
+									Val: cty.StringVal("hello $$"),
 
 									SrcRange: hcl.Range{
 										Start: hcl.Pos{Line: 1, Column: 6, Byte: 5},
-										End:   hcl.Pos{Line: 1, Column: 12, Byte: 11},
-									},
-								},
-								// This parses oddly due to how the scanner
-								// handles escaping of the $ sequence, but it's
-								// functionally equivalent to a single literal.
-								&LiteralValueExpr{
-									Val: cty.StringVal("$"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 12, Byte: 11},
-										End:   hcl.Pos{Line: 1, Column: 13, Byte: 12},
-									},
-								},
-								&LiteralValueExpr{
-									Val: cty.StringVal("$"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 13, Byte: 12},
 										End:   hcl.Pos{Line: 1, Column: 14, Byte: 13},
 									},
 								},
@@ -939,18 +888,10 @@ block "valid" {}
 						Expr: &TemplateExpr{
 							Parts: []Expression{
 								&LiteralValueExpr{
-									Val: cty.StringVal("hello "),
+									Val: cty.StringVal("hello $"),
 
 									SrcRange: hcl.Range{
 										Start: hcl.Pos{Line: 1, Column: 6, Byte: 5},
-										End:   hcl.Pos{Line: 1, Column: 12, Byte: 11},
-									},
-								},
-								&LiteralValueExpr{
-									Val: cty.StringVal("$"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 12, Byte: 11},
 										End:   hcl.Pos{Line: 1, Column: 13, Byte: 12},
 									},
 								},
@@ -997,29 +938,10 @@ block "valid" {}
 						Expr: &TemplateExpr{
 							Parts: []Expression{
 								&LiteralValueExpr{
-									Val: cty.StringVal("hello "),
+									Val: cty.StringVal("hello %%"),
 
 									SrcRange: hcl.Range{
 										Start: hcl.Pos{Line: 1, Column: 6, Byte: 5},
-										End:   hcl.Pos{Line: 1, Column: 12, Byte: 11},
-									},
-								},
-								// This parses oddly due to how the scanner
-								// handles escaping of the % sequence, but it's
-								// functionally equivalent to a single literal.
-								&LiteralValueExpr{
-									Val: cty.StringVal("%"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 12, Byte: 11},
-										End:   hcl.Pos{Line: 1, Column: 13, Byte: 12},
-									},
-								},
-								&LiteralValueExpr{
-									Val: cty.StringVal("%"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 13, Byte: 12},
 										End:   hcl.Pos{Line: 1, Column: 14, Byte: 13},
 									},
 								},
@@ -1066,18 +988,10 @@ block "valid" {}
 						Expr: &TemplateExpr{
 							Parts: []Expression{
 								&LiteralValueExpr{
-									Val: cty.StringVal("hello "),
+									Val: cty.StringVal("hello %"),
 
 									SrcRange: hcl.Range{
 										Start: hcl.Pos{Line: 1, Column: 6, Byte: 5},
-										End:   hcl.Pos{Line: 1, Column: 12, Byte: 11},
-									},
-								},
-								&LiteralValueExpr{
-									Val: cty.StringVal("%"),
-
-									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 12, Byte: 11},
 										End:   hcl.Pos{Line: 1, Column: 13, Byte: 12},
 									},
 								},


### PR DESCRIPTION
When processing a template string, the lexer can emit multiple string literal tokens for what ought to be a single string literal. This occurs when the string contains escape sequences, or consecutive characters which are indistinguishable from escape sequences at tokenization time.

This leads to a confusing AST and causes heuristics about template expressions to fail. Specifically, when parsing a traversal with an index, a key value containing an escape symbol will cause the parser to generate an index expression instead of a traversal.

This commit adds a post-processing step to the template parser to meld any sequences of string literals into a single string literal. Existing tests covered the previous misbehaviour (several of which had comments apologizing for it), and have been updated accordingly.

The new behaviour of the `IsStringLiteral` method of `TemplateExpr` is covered with a new set of tests.

---

This change fixes a downstream bug in Terraform which is not currently tracked on GitHub. Apply the following configuration:

```terraform
resource "null_resource" "none" {
}
```

Then update the configuration as follows:

```terraform
resource "null_resource" "none" {
  for_each = toset(["$foo"])
}

moved {
  from = null_resource.none
  to   = null_resource.none["$foo"]
}
```

This should plan the move operation. Without this change, it results in the following error:

```
╷
│ Error: Invalid expression
│
│   on main.tf line 7, in moved:
│    7:   to   = null_resource.none["$foo"]
│
│ A single static variable reference is required: only attribute access and
│ indexing with constant keys. No calculations, function calls, template
│ expressions, etc are allowed here.
╵
```