### PR TITLE
support TraverseSplat for hclwrite.TokensForTraversal

### DIFF
--- a/hclwrite/generate.go
+++ b/hclwrite/generate.go
@@ -337,6 +337,21 @@ func appendTokensForTraversalStep(step hcl.Traverser, toks Tokens) Tokens {
 			Type:  hclsyntax.TokenCBrack,
 			Bytes: []byte{']'},
 		})
+	case hcl.TraverseSplat:
+		toks = append(toks,
+			&Token{
+				Type:  hclsyntax.TokenOBrack,
+				Bytes: []byte{'['},
+			},
+			&Token{
+				Type:  hclsyntax.TokenStar,
+				Bytes: []byte{'*'},
+			},
+			&Token{
+				Type:  hclsyntax.TokenCBrack,
+				Bytes: []byte{']'},
+			},
+		)
 	default:
 		panic(fmt.Sprintf("unsupported traversal step type %T", step))
 	}

--- a/hclwrite/generate_test.go
+++ b/hclwrite/generate_test.go
@@ -506,6 +506,7 @@ func TestTokensForTraversal(t *testing.T) {
 				hcl.TraverseRoot{Name: "root"},
 				hcl.TraverseAttr{Name: "attr"},
 				hcl.TraverseIndex{Key: cty.StringVal("index")},
+				hcl.TraverseSplat{},
 			},
 			Tokens{
 				{Type: hclsyntax.TokenIdent, Bytes: []byte("root")},
@@ -515,6 +516,9 @@ func TestTokensForTraversal(t *testing.T) {
 				{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`)},
 				{Type: hclsyntax.TokenQuotedLit, Bytes: []byte("index")},
 				{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenCBrack, Bytes: []byte{']'}},
+				{Type: hclsyntax.TokenOBrack, Bytes: []byte{'['}},
+				{Type: hclsyntax.TokenStar, Bytes: []byte("*")},
 				{Type: hclsyntax.TokenCBrack, Bytes: []byte{']'}},
 			},
 		},

--- a/traversal.go
+++ b/traversal.go
@@ -280,7 +280,6 @@ func (tn TraverseIndex) SourceRange() Range {
 // TraverseSplat applies the splat operation to its initial value.
 type TraverseSplat struct {
 	isTraverser
-	Each     Traversal
 	SrcRange Range
 }
 


### PR DESCRIPTION
I am working on some tooling to generate HCL and found that the `hclwrite.TokensForTraversal` method does not support the `hcl.TraverseSplat` traverser.

I could also not find any use of `hcl.TraverseSplat` in the `hcl` package, or in the Terraform code base, so not sure where it is actually used.

Any chance this could be added to the core `hcl` package? Right now I am relying on my fork and it works great.