### PR TITLE
hclsyntax: Report correct Range.End for FunctionCall w/ incomplete arg

### DIFF
--- a/hclsyntax/parser.go
+++ b/hclsyntax/parser.go
@@ -1174,7 +1174,12 @@ Token:
 			// if there was a parse error in the argument then we've
 			// probably been left in a weird place in the token stream,
 			// so we'll bail out with a partial argument list.
-			p.recover(TokenCParen)
+			recoveredTok := p.recover(TokenCParen)
+
+			// record the recovered token, if one was found
+			if recoveredTok.Type == TokenCParen {
+				closeTok = recoveredTok
+			}
 			break Token
 		}
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/hcl/issues/582

Passing tests suggest this isn't breaking anything else, but I'm open to suggestions for any more (careful) changes to avoid any unforeseen consequences.