### PR TITLE
Typo fix: Consecutive occurrences of 'the'

### DIFF
--- a/traversal_for_expr.go
+++ b/traversal_for_expr.go
@@ -16,7 +16,7 @@ package hcl
 //
 // In most cases the calling application is interested in the value
 // that results from an expression, but in rarer cases the application
-// needs to see the the name of the variable and subsequent
+// needs to see the name of the variable and subsequent
 // attributes/indexes itself, for example to allow users to give references
 // to the variables themselves rather than to their values. An implementer
 // of this function should at least support attribute and index steps.


### PR DESCRIPTION
Remove consecutive occurrences of 'the'
`s/the the /the /g`