### PR TITLE
SetAttribute* methods are not returning new Attribute

### DIFF
--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -150,7 +150,7 @@ func (b *Body) SetAttributeRaw(name string, tokens Tokens) *Attribute {
 	if attr != nil {
 		attr.expr = attr.expr.ReplaceWith(expr)
 	} else {
-		attr := newAttribute()
+		attr = newAttribute()
 		attr.init(name, expr)
 		b.appendItem(attr)
 	}
@@ -171,7 +171,7 @@ func (b *Body) SetAttributeValue(name string, val cty.Value) *Attribute {
 	if attr != nil {
 		attr.expr = attr.expr.ReplaceWith(expr)
 	} else {
-		attr := newAttribute()
+		attr = newAttribute()
 		attr.init(name, expr)
 		b.appendItem(attr)
 	}
@@ -192,7 +192,7 @@ func (b *Body) SetAttributeTraversal(name string, traversal hcl.Traversal) *Attr
 	if attr != nil {
 		attr.expr = attr.expr.ReplaceWith(expr)
 	} else {
-		attr := newAttribute()
+		attr = newAttribute()
 		attr.init(name, expr)
 		b.appendItem(attr)
 	}


### PR DESCRIPTION
The SetAttribute* methods are supposed to return the considered attribute (new or existing) However, because of the variable shadowing in the creation path,  it does not return the new Attribute and instead return nil

Fix the code to return the create Attribute when it is not already present in the body