### PR TITLE
hclsyntax: Impose an upper limit on a refined prefix in TemplateExpr

### DIFF
--- a/hclsyntax/expression_template.go
+++ b/hclsyntax/expression_template.go
@@ -94,7 +94,16 @@ func (e *TemplateExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 		ret = cty.UnknownVal(cty.String)
 		if !diags.HasErrors() { // Invalid input means our partial result buffer is suspect
 			if knownPrefix := buf.String(); knownPrefix != "" {
-				ret = ret.Refine().StringPrefix(knownPrefix).NewValue()
+				byteLen := len(knownPrefix)
+				// Impose a reasonable upper limit to avoid producing too long a prefix.
+				// The 128 B is about 10% of the safety limits in cty's msgpack decoder.
+				// @see https://github.com/zclconf/go-cty/blob/v1.13.2/cty/msgpack/unknown.go#L170-L175
+				//
+				// This operation is safe because StringPrefix removes incomplete trailing grapheme clusters.
+				if byteLen > 128 { // arbitrarily-decided threshold
+					byteLen = 128
+				}
+				ret = ret.Refine().StringPrefix(knownPrefix[:byteLen]).NewValue()
 			}
 		}
 	} else {

--- a/hclsyntax/expression_template_test.go
+++ b/hclsyntax/expression_template_test.go
@@ -4,6 +4,7 @@
 package hclsyntax
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -305,6 +306,16 @@ trim`,
 				},
 			},
 			cty.UnknownVal(cty.String).Refine().NotNull().StringPrefixFull("test_known_").NewValue(),
+			0,
+		},
+		{ // can preserve a static prefix as a refinement, but the length is limited to 128 B
+			strings.Repeat("_", 130) + `${unknown}`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"unknown": cty.UnknownVal(cty.String),
+				},
+			},
+			cty.UnknownVal(cty.String).Refine().NotNull().StringPrefixFull(strings.Repeat("_", 128)).NewValue(),
 			0,
 		},
 		{ // marks from uninterpolated values are ignored


### PR DESCRIPTION
Fixes https://github.com/hashicorp/hcl/issues/616

There is no limit to the length of string prefixes produced by template expressions, so in rare cases they may return a refined unknown string has too long a prefix.

The `cty`'s msgpack decoder limits the size of an acceptable refinements to 1 kiB, so such a value cannot be handled and an error occurs.

This change limits the length of prefixes to 128 B, so overly long prefixes are no longer an issue in most cases.