### PR TITLE
ext/typeexpr: Avoid refinements on dynamic values

### DIFF
--- a/ext/typeexpr/defaults.go
+++ b/ext/typeexpr/defaults.go
@@ -95,7 +95,7 @@ func (d *Defaults) apply(v cty.Value) cty.Value {
 				}
 				values[key] = defaultValue
 			}
-			if defaultRng := defaultValue.Range(); defaultRng.DefinitelyNotNull() {
+			if defaultRng := defaultValue.Range(); defaultRng.DefinitelyNotNull() && values[key].Type() != cty.DynamicPseudoType {
 				values[key] = values[key].RefineNotNull()
 			}
 		}

--- a/ext/typeexpr/defaults_test.go
+++ b/ext/typeexpr/defaults_test.go
@@ -898,6 +898,23 @@ func TestDefaults_Apply(t *testing.T) {
 				"foo": cty.UnknownVal(cty.String).RefineNotNull(),
 			}),
 		},
+		"optional attribute with dynamic value can be null": {
+			defaults: &Defaults{
+				Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+					"foo": cty.String,
+				}, []string{"foo"}),
+				DefaultValues: map[string]cty.Value{
+					"foo": cty.StringVal("bar"), // Important: default is non-null
+				},
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.DynamicVal,
+			}),
+			want: cty.ObjectVal(map[string]cty.Value{
+				// The default value is itself non-null, but dynamic value cannot be refined.
+				"foo": cty.DynamicVal,
+			}),
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
See also https://github.com/hashicorp/hcl/pull/590
See also https://github.com/terraform-linters/tflint/issues/1831

Refinements introduced in #590 has a restriction that it cannot refine unknown values of unknown types (`cty.DynamicVal`). Refining dynamic values causes a panic.
https://github.com/zclconf/go-cty/blob/v1.13.3/cty/unknown_refinement.go#L46-L47

The `typeexpr` extension may refine optional attribute as non-null, but dynamic values are not taken into account here, causing a panic.

This PR fixes the panic by avoiding refinement when the value type is `cty.DynamicPseudoType`. This is the same approach in the splat operator, so it's probably reasonable to do the same here.
https://github.com/hashicorp/hcl/blob/a9f8d65cae3cf64e58fc38f85c7970ab62964e8b/hclsyntax/expression.go#L1735-L1737

As a side note, I reviewed #590 again, and this is probably the only place we should consider dynamic values. Perhaps the `hcldec` also requires a determination before calling `RefineWith`, but I'm not familiar enough with the `hcldec` package, so I haven't included it here.
https://github.com/hashicorp/hcl/blob/a9f8d65cae3cf64e58fc38f85c7970ab62964e8b/hcldec/spec.go#L1643