### PR TITLE
hclsyntax, hcldec: Just some extra tests for marks and refinements interacting together

### DIFF
--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1397,6 +1397,26 @@ upper(
 			}).Mark("sensitive"),
 			0,
 		},
+		{ // splat with sensitive collection that's unknown
+			`maps.*.enabled`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"maps": cty.UnknownVal(cty.List(cty.Map(cty.Bool))).Mark("sensitive"),
+				},
+			},
+			cty.UnknownVal(cty.List(cty.Bool)).RefineNotNull().Mark("sensitive"),
+			0,
+		},
+		{ // splat with sensitive collection that's unknown and not null
+			`maps.*.enabled`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"maps": cty.UnknownVal(cty.List(cty.Map(cty.Bool))).RefineNotNull().Mark("sensitive"),
+				},
+			},
+			cty.UnknownVal(cty.List(cty.Bool)).RefineNotNull().Mark("sensitive"),
+			0,
+		},
 		{ // splat with collection with sensitive elements
 			`maps.*.x`,
 			&hcl.EvalContext{


### PR DESCRIPTION
In https://github.com/hashicorp/hcl/pull/630, and a couple other similar situations found while debugging that one, it became clear that interactions between refinements and marks are a bit of a hazard, since each involves a different kind of tag-along metadata that needs to be carefully preserved during evaluation.

That prompted me to go review the other refinements-related code added at the same time. I didn't yet find any specific bugs, but this PR includes some of the tests I added while I was reviewing, to help exercise more interactions between refinement and marks.

This doesn't change any non-test code.
