### PR TITLE
ext/dynblock: Allow callers to veto for_each values

### DIFF
--- a/ext/dynblock/expand_body.go
+++ b/ext/dynblock/expand_body.go
@@ -17,6 +17,8 @@ type expandBody struct {
 	forEachCtx *hcl.EvalContext
 	iteration  *iteration // non-nil if we're nested inside another "dynamic" block
 
+	checkForEach []func(cty.Value, hcl.Expression, *hcl.EvalContext) hcl.Diagnostics
+
 	// These are used with PartialContent to produce a "remaining items"
 	// body to return. They are nil on all bodies fresh out of the transformer.
 	//
@@ -66,6 +68,7 @@ func (b *expandBody) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, h
 		original:     b.original,
 		forEachCtx:   b.forEachCtx,
 		iteration:    b.iteration,
+		checkForEach: b.checkForEach,
 		hiddenAttrs:  make(map[string]struct{}),
 		hiddenBlocks: make(map[string]hcl.BlockHeaderSchema),
 	}
@@ -236,6 +239,7 @@ func (b *expandBody) expandChild(child hcl.Body, i *iteration) hcl.Body {
 	chiCtx := i.EvalContext(b.forEachCtx)
 	ret := Expand(child, chiCtx)
 	ret.(*expandBody).iteration = i
+	ret.(*expandBody).checkForEach = b.checkForEach
 	return ret
 }
 

--- a/ext/dynblock/options.go
+++ b/ext/dynblock/options.go
@@ -1,0 +1,23 @@
+package dynblock
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type ExpandOption interface {
+	applyExpandOption(*expandBody)
+}
+
+type optCheckForEach struct {
+	check func(cty.Value, hcl.Expression, *hcl.EvalContext) hcl.Diagnostics
+}
+
+func OptCheckForEach(check func(cty.Value, hcl.Expression, *hcl.EvalContext) hcl.Diagnostics) ExpandOption {
+	return optCheckForEach{check}
+}
+
+// applyExpandOption implements ExpandOption.
+func (o optCheckForEach) applyExpandOption(body *expandBody) {
+	body.checkForEach = append(body.checkForEach, o.check)
+}

--- a/ext/dynblock/public.go
+++ b/ext/dynblock/public.go
@@ -27,24 +27,28 @@ import (
 // multi-dimensional iteration. However, it is not possible to
 // dynamically-generate the "dynamic" blocks themselves except through nesting.
 //
-//     parent {
-//       dynamic "child" {
-//         for_each = child_objs
-//         content {
-//           dynamic "grandchild" {
-//             for_each = child.value.children
-//             labels   = [grandchild.key]
-//             content {
-//               parent_key = child.key
-//               value      = grandchild.value
-//             }
-//           }
-//         }
-//       }
-//     }
-func Expand(body hcl.Body, ctx *hcl.EvalContext) hcl.Body {
-	return &expandBody{
+//	parent {
+//	  dynamic "child" {
+//	    for_each = child_objs
+//	    content {
+//	      dynamic "grandchild" {
+//	        for_each = child.value.children
+//	        labels   = [grandchild.key]
+//	        content {
+//	          parent_key = child.key
+//	          value      = grandchild.value
+//	        }
+//	      }
+//	    }
+//	  }
+//	}
+func Expand(body hcl.Body, ctx *hcl.EvalContext, opts ...ExpandOption) hcl.Body {
+	ret := &expandBody{
 		original:   body,
 		forEachCtx: ctx,
 	}
+	for _, opt := range opts {
+		opt.applyExpandOption(ret)
+	}
+	return ret
 }


### PR DESCRIPTION
Callers might have additional rules for what's acceptable in a `for_each` value for a dynamic block. For example, Terraform wants to forbid using sensitive values here because it would cause the expansion to disclose the length of the given collection, but currently ends up returning a very low-quality (highly misleading) error in that case, as discussed in hashicorp/terraform#29744 .

Therefore this provides a hook point for callers to insert additional checks just after the for_each expression has been evaluated and before any of the built-in checks are run. Terraform can use this to check whether the `for_each` value is sensitive, and if so to return a specialized error about that which:
- Has the given expression and eval context included in the diagnostic, so Terraform's diagnostic UI code can show all of the external values that contributed to the `for_each` expression.
- Is annotated using the Terraform-specific "extra" annotation that an error is caused by sensitive values, which permits the UI to mention which values are sensitive as part of the error message. (Terraform doesn't do that by default, because we found that folks often assumed that Terraform would only mention that a value is sensitive if that was what caused the error, and and so often skipped reading any other part of the error message as soon as there was any mention of that.)

This would therefore allow a future change to Terraform itself to make it return a helpful error message in this situation, similar to the one it already returns for its own `for_each` features in the same situation.

This introduces the "functional options" pattern for `dynblock.ExpandBlock` for the first time, as a way to extend the API without breaking compatibility with existing callers. There is currently only this one option.

