### PR TITLE
hclparse/parser: open error fixes

### DIFF
--- a/hclparse/parser.go
+++ b/hclparse/parser.go
@@ -76,7 +76,7 @@ func (p *Parser) ParseHCLFile(filename string) (*hcl.File, hcl.Diagnostics) {
 			{
 				Severity: hcl.DiagError,
 				Summary:  "Failed to read file",
-				Detail:   fmt.Sprintf("The configuration file %#q could not be read.", filename),
+				Detail:   fmt.Sprintf("The configuration file %#q could not be read: %s", filename, err),
 			},
 		}
 	}

--- a/hclparse/parser.go
+++ b/hclparse/parser.go
@@ -76,7 +76,7 @@ func (p *Parser) ParseHCLFile(filename string) (*hcl.File, hcl.Diagnostics) {
 			{
 				Severity: hcl.DiagError,
 				Summary:  "Failed to read file",
-				Detail:   fmt.Sprintf("The configuration file %q could not be read.", filename),
+				Detail:   fmt.Sprintf("The configuration file %#q could not be read.", filename),
 			},
 		}
 	}


### PR DESCRIPTION
As reported by a user on Packer (refer to issue https://github.com/hashicorp/packer/issues/12726 for context), the `ParseHCLFile` returns a diagnostic that can be misleading in terms of the path presented because of the escaping that `%q` applies.
This, coupled with the fact that the `err` returned by `os.ReadFile` is not forwarded may cause some confusion among users, so we try to change this with that PR.