### PR TITLE
Prevent hidden blocks from causing an error in hcl.Body.JustAttributes

### DIFF
--- a/hclsyntax/structure.go
+++ b/hclsyntax/structure.go
@@ -249,14 +249,17 @@ func (b *Body) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
 	attrs := make(hcl.Attributes)
 	var diags hcl.Diagnostics
 
-	if len(b.Blocks) > 0 {
-		example := b.Blocks[0]
+	for _, block := range b.Blocks {
+		if _, hidden := b.hiddenBlocks[block.Type]; hidden {
+			continue
+		}
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("Unexpected %q block", example.Type),
+			Summary:  fmt.Sprintf("Unexpected %q block", block.Type),
 			Detail:   "Blocks are not allowed here.",
-			Subject:  &example.TypeRange,
+			Subject:  &block.TypeRange,
 		})
+		break
 		// we will continue processing anyway, and return the attributes
 		// we are able to find so that certain analyses can still be done
 		// in the face of errors.

--- a/hclsyntax/structure_test.go
+++ b/hclsyntax/structure_test.go
@@ -498,6 +498,33 @@ func TestBodyJustAttributes(t *testing.T) {
 						},
 					},
 				},
+				Blocks: Blocks{
+					{
+						Type: "foo",
+					},
+				},
+				hiddenBlocks: map[string]struct{}{"foo": {}},
+			},
+			hcl.Attributes{
+				"foo": &hcl.Attribute{
+					Name: "foo",
+					Expr: &LiteralValueExpr{
+						Val: cty.StringVal("bar"),
+					},
+				},
+			},
+			0, // hidden blocks are ignored, so no error
+		},
+		{
+			&Body{
+				Attributes: Attributes{
+					"foo": &Attribute{
+						Name: "foo",
+						Expr: &LiteralValueExpr{
+							Val: cty.StringVal("bar"),
+						},
+					},
+				},
 				hiddenAttrs: map[string]struct{}{
 					"foo": struct{}{},
 				},


### PR DESCRIPTION
Currently `hcl.Body.JustAttributes` produces an error if there are any blocks in the `hcl.Body`. It seems to me that this is incorrect: we should produce an error only if there are non-hidden blocks in the body.

<details>
<summary>Motivating example</summary>

```go
package main

import (
	"fmt"
	"os"

	"github.com/hashicorp/hcl/v2"
	"github.com/hashicorp/hcl/v2/gohcl"
	"github.com/hashicorp/hcl/v2/hclsyntax"
)

func dieOnError(diags hcl.Diagnostics) {
	if diags.HasErrors() {
		fmt.Println("Error:", diags)
		os.Exit(1)
	}
}

type Inner struct {
	Foo string `hcl:"foo"`
}

type Example struct {
	Inner Inner    `hcl:"inner,block"`
	Rest  hcl.Body `hcl:",remain"`
}

func main() {
	f, diag := hclsyntax.ParseConfig(
		[]byte(`
inner {
	foo = "foo"
}
bar = "bar"
`),
		"example.hcl",
		hcl.InitialPos,
	)
	dieOnError(diag)

	var ex Example
	diag = gohcl.DecodeBody(f.Body, nil, &ex)
	dieOnError(diag)

	attrs, diag := ex.Rest.JustAttributes()
	fmt.Printf("attrs are correct: %+v\n", attrs)
	dieOnError(diag)
}
```

Expected output:
```
attrs are correct: map[bar:0xc0000ea320]
```

Current output:
```
attrs are correct: map[bar:0xc0000ea320]
Error: example.hcl:2,1-6: Unexpected "inner" block; Blocks are not allowed here.
```
</details>

I'm not that experienced with HCL, but it seems like a bug in `JustAttributes` implementation