### PR TITLE
hclwrite: Fix formatting of namespaced functions

### DIFF
--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -455,14 +455,11 @@ func tokenBracketChange(tok *Token) int {
 // formatLine represents a single line of source code for formatting purposes,
 // splitting its tokens into up to three "cells":
 //
-// lead: always present, representing everything up to one of the others
-// assign: if line contains an attribute assignment, represents the tokens
-//
-//	starting at (and including) the equals symbol
-//
-// comment: if line contains any non-comment tokens and ends with a
-//
-//	single-line comment token, represents the comment.
+//   - lead: always present, representing everything up to one of the others
+//   - assign: if line contains an attribute assignment, represents the tokens
+//     starting at (and including) the equals symbol
+//   - comment: if line contains any non-comment tokens and ends with a
+//     single-line comment token, represents the comment.
 //
 // When formatting, the leading spaces of the first tokens in each of these
 // cells is adjusted to align vertically their occurences on consecutive

--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -457,9 +457,12 @@ func tokenBracketChange(tok *Token) int {
 //
 // lead: always present, representing everything up to one of the others
 // assign: if line contains an attribute assignment, represents the tokens
-//    starting at (and including) the equals symbol
+//
+//	starting at (and including) the equals symbol
+//
 // comment: if line contains any non-comment tokens and ends with a
-//    single-line comment token, represents the comment.
+//
+//	single-line comment token, represents the comment.
 //
 // When formatting, the leading spaces of the first tokens in each of these
 // cells is adjusted to align vertically their occurences on consecutive

--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -234,6 +234,11 @@ func spaceAfterToken(subject, before, after *Token) bool {
 		// Don't split a function name from open paren in a call
 		return false
 
+	case (subject.Type == hclsyntax.TokenIdent && after.Type == hclsyntax.TokenDoubleColon) ||
+		(subject.Type == hclsyntax.TokenDoubleColon && after.Type == hclsyntax.TokenIdent):
+		// Don't split namespace segments in a function call
+		return false
+
 	case subject.Type == hclsyntax.TokenDot || after.Type == hclsyntax.TokenDot:
 		// Don't use spaces around attribute access dots
 		return false

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -615,6 +615,10 @@ module "x" {
   abcde = "456"
 }`,
 		},
+		{
+			`attr = provider::framework::example()`,
+			`attr = provider::framework::example()`,
+		},
 	}
 
 	for i, test := range tests {

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -620,6 +620,14 @@ module "x" {
 			`attr = provider::framework::example()`,
 		},
 		{
+			`attr = provider :: framework :: example()`,
+			`attr = provider::framework::example()`,
+		},
+		{
+			`attr = provider ::framework:: example()`,
+			`attr = provider::framework::example()`,
+		},
+		{
 			// This is invalid syntax so formatting it with spaces
 			// does not have any meaning other than to make the fact more visible
 			`attr = provider::+example()`,

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -619,6 +619,12 @@ module "x" {
 			`attr = provider::framework::example()`,
 			`attr = provider::framework::example()`,
 		},
+		{
+			// This is invalid syntax so formatting it with spaces
+			// does not have any meaning other than to make the fact more visible
+			`attr = provider::+example()`,
+			`attr = provider:: + example()`,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
## Before

```sh
echo 'attr = provider::framework::example()' | terraform fmt -
```
```hcl
attr = provider :: framework :: example()
```

## After

```sh
echo 'attr = provider::framework::example()' | terraform fmt -
```
```hcl
attr = provider::framework::example()
```
