### PR TITLE
Run unit tests on macOS

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Per-commit Checks
+name: Checks
 
 on:
   push:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,8 @@ jobs:
             target: linux_amd64
           - runs-on: windows-latest
             target: windows_amd64
+          - runs-on: macos-latest
+            target: darwin_amd64
       fail-fast: false
 
     name: "Unit Tests on ${{ matrix.target }}"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - name: Go test
         run: |
           go test ./... -race
@@ -49,7 +49,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - name: "Check vet"
         run: |
           go vet ./...


### PR DESCRIPTION
## Run tests on macOS

Previously we did not run unit tests on macOS. I don't know all the history but I will assume that was because the macOS runners were not available early on, or were otherwise difficult to use.

It seems relatively unlikely that there would be macOS-specific bugs we could discover that aren't more broadly Unix bugs (i.e. bugs that would be surfaced through Linux tests).

Regardless, the reality is that the products downstream of HCL, such as Terraform, do have macOS user base and we regularly run tests on macOS, so it would seem reasonable to also do it here.

## Read Go version from `go.mod`

While strictly speaking the version in `go.mod` is _compatibility constraint_, we always seem to test against that version, i.e. there is no difference in practice between the version we claim compatibility with and the version we test against.

We could start testing _additionally_ against newer Go versions too but I was trying to keep this PR small in scope, to keep the review easier.
