### PR TITLE
Add make targets for common checks + fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+fmtcheck:
+	"$(CURDIR)/scripts/gofmtcheck.sh"
+
+fmtfix:
+	gofmt -w ./
+
+vetcheck:
+	go vet ./...
+
+copyrightcheck:
+	go run github.com/hashicorp/copywrite@latest headers --plan
+
+copyrightfix:
+	go run github.com/hashicorp/copywrite@latest headers
+
+check: copyrightcheck vetcheck fmtcheck
+
+fix: copyrightfix fmtfix

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+if [[ -n $(gofmt -l ./) ]]; then echo "Please run gofmt -w ./ to format code"; exit 1; fi;


### PR DESCRIPTION
This is to make it easier for existing and new maintainers and contributors to run checks on the codebase.

These targets can also run from CI which can be implemented as part of a separate PR.

## Examples

```sh
make check
```
```
go run github.com/hashicorp/copywrite@latest headers --plan
Executing in dry-run mode. Rerun without the `--plan` flag to apply changes.

Using license identifier: MPL-2.0
Using copyright holder: HashiCorp, Inc.

Exempting the following search patterns:
hclsyntax/fuzz/testdata/**
hclwrite/fuzz/testdata/**
json/fuzz/testdata/**
specsuite/tests/**

The following files are missing headers:
go vet ./...
"/Users/radeksimko/gopath/src/github.com/hashicorp/hcl/scripts/gofmtcheck.sh"
```

```sh
make fix
```
```
go run github.com/hashicorp/copywrite@latest headers
Using license identifier: MPL-2.0
Using copyright holder: HashiCorp, Inc.

Exempting the following search patterns:
hclsyntax/fuzz/testdata/**
hclwrite/fuzz/testdata/**
json/fuzz/testdata/**
specsuite/tests/**

The following files are missing headers:
2024-02-16T15:25:27.173Z [INFO]  cli: ext/dynblock/options.go modified
gofmt -w ./
```

## Notes

Please note that the license checks specifically are currently failing. That is being fixed in https://github.com/hashicorp/hcl/pull/659