### PR TITLE
hclsyntax: Correct copyrights on unicode2ragel.rb

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -8,6 +8,7 @@ project {
   # Supports doublestar glob patterns for more flexibility in defining which
   # files or folders should be ignored
   header_ignore = [
+    "hclsyntax/unicode2ragel.rb",
     "hclsyntax/fuzz/testdata/**",
     "hclwrite/fuzz/testdata/**",
     "json/fuzz/testdata/**",

--- a/hclsyntax/unicode2ragel.rb
+++ b/hclsyntax/unicode2ragel.rb
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
 
 #
 # This scripted has been updated to accept more command-line arguments:


### PR DESCRIPTION
Nobody at HashiCorp has so far contributed to this particular file, therefore this PR is reflecting that fact by ignore-listing it via the copywrite config and removing the existing header.