### PR TITLE
fix panic for partial provider defined functions in tuple expressions (`[ provider:: ]`)

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1133,7 +1133,9 @@ type TupleConsExpr struct {
 
 func (e *TupleConsExpr) walkChildNodes(w internalWalkFunc) {
 	for _, expr := range e.Exprs {
-		w(expr)
+		if expr != nil {
+			w(expr)
+		}
 	}
 }
 

--- a/hclsyntax/variables_test.go
+++ b/hclsyntax/variables_test.go
@@ -293,6 +293,15 @@ func TestVariables(t *testing.T) {
 				},
 			},
 		},
+		{
+			// happens e.g. when parsing an invalid [ provider:: ]
+			&TupleConsExpr{
+				Exprs: []Expression{
+					nil,
+				},
+			},
+			nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When parsing invalid provider defined functions, a `nil` expression is returned. While there are diagnostics that correctly tell us about invalid configuration, in the editor we still need to continue working with the invalid configuration.

This fix allows us to call `Variables()` on expressions that may have a nested nil in a tuple somewhere. We do this e.g. when [collecting reference origins](https://github.com/hashicorp/hcl-lang/blob/4db48f4b5961120c51b11216d040c095c0fd4a76/decoder/expr_any_ref_origins.go#L174) and instead of digging into the expressions at hand and deciding whether to call `.Variables()` or not, fixing it at the source seems more useful.