### PR TITLE
fix: be more graceful when trying to access the value of an invalid expression template

### DIFF
--- a/hclsyntax/expression_template.go
+++ b/hclsyntax/expression_template.go
@@ -33,6 +33,11 @@ func (e *TemplateExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 	marks := make(cty.ValueMarks)
 
 	for _, part := range e.Parts {
+		if part == nil {
+			// we silently ignore nil parts as they only occur for configuration that is already known to be invalid
+			continue
+		}
+
 		partVal, partDiags := part.Value(ctx)
 		diags = append(diags, partDiags...)
 

--- a/hclsyntax/expression_template.go
+++ b/hclsyntax/expression_template.go
@@ -250,6 +250,10 @@ func (e *TemplateWrapExpr) walkChildNodes(w internalWalkFunc) {
 }
 
 func (e *TemplateWrapExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+	if e.Wrapped == nil {
+		return cty.NilVal, nil
+	}
+
 	return e.Wrapped.Value(ctx)
 }
 

--- a/hclsyntax/expression_template_test.go
+++ b/hclsyntax/expression_template_test.go
@@ -438,6 +438,17 @@ trim`,
 
 }
 
+func TestTemplateExprGracefulValue(t *testing.T) {
+	// we don't care about diags since we know it's invalid config
+	expr, _ := ParseTemplate([]byte(`${provider::}`), "", hcl.Pos{Line: 1, Column: 1, Byte: 0})
+
+	got, _ := expr.Value(nil) // this should not panic
+
+	if !got.RawEquals(cty.NilVal) {
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, cty.NilVal)
+	}
+}
+
 func TestTemplateExprIsStringLiteral(t *testing.T) {
 	tests := map[string]bool{
 		// A simple string value is a string literal

--- a/hclsyntax/expression_template_test.go
+++ b/hclsyntax/expression_template_test.go
@@ -440,6 +440,17 @@ trim`,
 
 func TestTemplateExprGracefulValue(t *testing.T) {
 	// we don't care about diags since we know it's invalid config
+	expr, _ := ParseTemplate([]byte(`prefix${provider::}`), "", hcl.Pos{Line: 1, Column: 1, Byte: 0})
+
+	got, _ := expr.Value(nil) // this should not panic
+
+	if !got.RawEquals(cty.StringVal("prefix")) {
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, cty.NilVal)
+	}
+}
+
+func TestTemplateExprWrappedGracefulValue(t *testing.T) {
+	// we don't care about diags since we know it's invalid config
 	expr, _ := ParseTemplate([]byte(`${provider::}`), "", hcl.Pos{Line: 1, Column: 1, Byte: 0})
 
 	got, _ := expr.Value(nil) // this should not panic


### PR DESCRIPTION
The editor extension needs to work with the available AST even if there were diagnostics / errors.
While typing out namespaced functions (e.g. during a partial `provider::`) this will produce expressions that are `nil` in various places.
This PR makes template expressions behave more graceful in such cases.