### PR TITLE
gohcl: Struct Embedding

### DIFF
--- a/gohcl/decode.go
+++ b/gohcl/decode.go
@@ -66,6 +66,11 @@ func decodeBodyToStruct(body hcl.Body, ctx *hcl.EvalContext, val reflect.Value) 
 		return diags
 	}
 
+	return append(diags, decodeBodyToStructInner(body, content, leftovers, ctx, val)...)
+}
+func decodeBodyToStructInner(body hcl.Body, content *hcl.BodyContent, leftovers hcl.Body, ctx *hcl.EvalContext, val reflect.Value) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
 	tags := getFieldTags(val.Type())
 
 	if tags.Body != nil {
@@ -97,6 +102,10 @@ func decodeBodyToStruct(body hcl.Body, ctx *hcl.EvalContext, val reflect.Value) 
 		default:
 			diags = append(diags, decodeBodyToValue(leftovers, ctx, fieldV)...)
 		}
+	}
+	for _, embedded := range tags.Embedded {
+		fieldV := val.Field(embedded.FieldIndex)
+		diags = append(diags, decodeBodyToStructInner(body, content, leftovers, ctx, fieldV)...)
 	}
 
 	for name, fieldIdx := range tags.Attributes {


### PR DESCRIPTION
A common pattern that does not currently work for decoding hcl is:
```go
type Base struct {
    Field string `hcl:"my_field"`
}

type Variant struct {
    Base
    Value int `hcl:"my_value"`
}
```

This is fixed  by making some recursive tweaks to schema.go and corresponding changes in decode and encode.  

This code is functional for decode, but still requires encode changes as well as test coverage.  I may end up refactoring this a bit as I fiddle with encode, but the core functionality is there.