### PR TITLE
Add additional function for parsing traversals with [*] keys

### DIFF
--- a/hclsyntax/parse_traversal_test.go
+++ b/hclsyntax/parse_traversal_test.go
@@ -261,7 +261,9 @@ func TestParseTraversalAbs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.src, func(t *testing.T) {
 			if test.src == "foo[*]" {
-				// Skip the test that introduces splat syntax.
+				// The foo[*] test will fail because the function we test in
+				// this branch does not support the splat syntax. So we will
+				// skip this test case here.
 				t.Skip("skipping test for unsupported splat syntax")
 			}
 
@@ -282,8 +284,11 @@ func TestParseTraversalAbs(t *testing.T) {
 
 		t.Run(fmt.Sprintf("partial_%s", test.src), func(t *testing.T) {
 			if test.src == "foo[*].bar" {
-				// Skip the test that's supposed to fail for splat syntax.
-				t.Skip("skipping test for unsupported splat syntax")
+				// The foo[*].bar test will fail because the function we test in
+				// this branch does support the splat syntax and this test is
+				// designed to make sure that the other branch still fails with
+				// the splat syntax. So we will skip this test case here.
+				t.Skip("skipping test that fails for splat syntax")
 			}
 
 			got, diags := ParseTraversalPartial([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})

--- a/hclsyntax/parse_traversal_test.go
+++ b/hclsyntax/parse_traversal_test.go
@@ -4,11 +4,13 @@
 package hclsyntax
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/hcl/v2"
 )
 
 func TestParseTraversalAbs(t *testing.T) {
@@ -208,11 +210,83 @@ func TestParseTraversalAbs(t *testing.T) {
 			},
 			1, // extra junk after traversal
 		},
+
+		{
+			"foo[*]",
+			hcl.Traversal{
+				hcl.TraverseRoot{
+					Name: "foo",
+					SrcRange: hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+				hcl.TraverseSplat{
+					SrcRange: hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 4, Byte: 3},
+						End:   hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+				},
+			},
+			0,
+		},
+		{
+			"foo.*", // Still not supporting this.
+			hcl.Traversal{
+				hcl.TraverseRoot{
+					Name: "foo",
+					SrcRange: hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+			1,
+		},
+		{
+			"foo[*].bar", // Run this through the unsupported function.
+			hcl.Traversal{
+				hcl.TraverseRoot{
+					Name: "foo",
+					SrcRange: hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+			1,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.src, func(t *testing.T) {
+			if test.src == "foo[*]" {
+				// Skip the test that introduces splat syntax.
+				t.Skip("skipping test for unsupported splat syntax")
+			}
+
 			got, diags := ParseTraversalAbs([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != test.diagCount {
+				for _, diag := range diags {
+					t.Logf(" - %s", diag.Error())
+				}
+				t.Errorf("wrong number of diagnostics %d; want %d", len(diags), test.diagCount)
+			}
+
+			if diff := deep.Equal(got, test.want); diff != nil {
+				for _, problem := range diff {
+					t.Error(problem)
+				}
+			}
+		})
+
+		t.Run(fmt.Sprintf("partial_%s", test.src), func(t *testing.T) {
+			if test.src == "foo[*].bar" {
+				// Skip the test that's supposed to fail for splat syntax.
+				t.Skip("skipping test for unsupported splat syntax")
+			}
+
+			got, diags := ParseTraversalPartial([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
 			if len(diags) != test.diagCount {
 				for _, diag := range diags {
 					t.Logf(" - %s", diag.Error())


### PR DESCRIPTION
This PR will eventually be used within Terraform to parse the "partial" addresses used by the deferred actions. We need support for the wildcards within traversals in order to reuse the larger logic for parsing traversals in general.

I've created a separate function for this so that this is a non-breaking change. For now, I haven't updated the behaviour of `SplatTraversal` so the automatic traversal functions will panic if called on a Traversal that contains the `[*]` index. We don't need this behaviour in Terraform (yet?) so I didn't want to introduce anything that couldn't be changed later.