### PR TITLE
hclsyntax: Don't panic if splat operand is unknown and marked

### DIFF
--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1457,6 +1457,16 @@ upper(
 			cty.UnknownVal(cty.List(cty.Bool)).RefineNotNull().Mark("sensitive"),
 			0,
 		},
+		{ // splat with sensitive non-collection that's unknown
+			`not_a_list.*`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"not_a_list": cty.UnknownVal(cty.EmptyObject).RefineNotNull().Mark("sensitive"),
+				},
+			},
+			cty.TupleVal([]cty.Value{cty.UnknownVal(cty.EmptyObject).RefineNotNull().Mark("sensitive")}).Mark("sensitive"),
+			0,
+		},
 		{ // splat with sensitive collection that's unknown and not null
 			`maps.*.enabled`,
 			&hcl.EvalContext{


### PR DESCRIPTION
This fixes a panic for `example.*` if `example` is an unknown value that's marked.

We were calling `.Range()` on any unknown `sourceVal`, without first checking whether it was marked. That method panics if called on a marked value, so we need to strip that off first.

While testing this I found some return paths that weren't properly transferring the source value's marks to the output, and so this also addresses those so that all return paths preserve whatever markings are present on the source value.

In particular, if a non-list/set/tuple value gets "upgraded" into a tuple then we must transfer its marks onto the tuple, because the decision about constructing that value was based on characteristics of the source value.