### PR TITLE
ext/dynblock: Preserve marks from for_each expression into result

### DIFF
--- a/ext/dynblock/expand_body.go
+++ b/ext/dynblock/expand_body.go
@@ -270,3 +270,8 @@ func (b *expandBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
 func (b *expandBody) MissingItemRange() hcl.Range {
 	return b.original.MissingItemRange()
 }
+
+// hcldec.MarkedBody impl
+func (b *expandBody) BodyValueMarks() cty.ValueMarks {
+	return b.valueMarks
+}

--- a/ext/dynblock/expand_body_test.go
+++ b/ext/dynblock/expand_body_test.go
@@ -762,7 +762,7 @@ func TestExpandMarkedForEach(t *testing.T) {
 			cty.ObjectVal(map[string]cty.Value{
 				"val0": cty.StringVal("static c 1").Mark("boop"),
 				"val1": cty.StringVal("hey").Mark("boop"),
-			}),
+			}).Mark("boop"),
 		})
 		got, diags := hcldec.Decode(dynBody, decSpec, nil)
 		if diags.HasErrors() {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7
 	github.com/spf13/pflag v1.0.2
 	github.com/zclconf/go-cty v1.13.0
-	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
+	github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167
 	golang.org/x/tools v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,10 @@ github.com/zclconf/go-cty v1.13.0 h1:It5dfKTTZHe9aeppbNOda3mN7Ag7sg6QkBNm6TkyFa0
 github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
+github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 h1:O8uGbHCqlTp2P6QJSLmCojM4mN6UemYv8K+dCnmHmu0=
 golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=


### PR DESCRIPTION
Previously if the `for_each` expression was marked then expansion would fail because marked expressions are never directly iterable. (The failure also had a very confusing error message, because it wasn't directly testing whether the value was marked and was just assuming that any non-iterable value is non-iterable because it's of the wrong type.)

Now instead we'll allow marked for_each and preserve the marks into the values produced by the resulting block as much as we can.

This runs into the classic problem that HCL blocks are not values themselves and so cannot carry marks directly, but we can at least make sure that the values of any leaf arguments end up marked. We also ensure that applications that use `hcldec` (which includes Terraform) will see marks on the objects that represent the blocks themselves, thereby improving the marking accuracy.

This also fixes a nearby bug that I found along the way: `dynblock` would previously panic if the value specified for a block label was marked. It will now return an error message, although the error message is not very good quality because HCL doesn't understand what any marks represent. If this becomes a problem in practice then perhaps in future we'll allow applications to specify their own label value validator functions so that they can customize the error messages, but dynamic labels are so rarely used right now that it doesn't seem worth that complexity.

---

Terraform-specific note: Terraform currently only uses its "sensitive" mark and configures `dynblock` to reject any `for_each` value that carries that mark, so this change effectively does nothing for today's Terraform because the new codepaths are unreachable anyway.

I've implemented this for https://github.com/hashicorp/terraform/pull/35078, because that introduces a new mark called "ephemeral" which represents that the value isn't required to be consistent between plan and apply and is never persisted in the state. It isn't appropriate to reject values with _that_ mark in dynamic block `for_each`, because we want to be able to use ephemeral values in provider configuration blocks and several heavily-used providers use nested blocks in their configuration schemas that might need to vary based on an ephemeral value.

(For example, consider an ephemeral input value for providing a JWT to use for AWS's "AssumeRoleWithWebIdentity". A JWT is a good example of something that's likely to vary between plan and apply and so would be declared as ephemeral, but it would be reasonable to use the nullness of that value to choose dynamically whether or not to include the `assume_role_with_web_identity` block, which requires that we allow the `for_each` result to be derived from the ephemeral value and therefore be ephemeral itself.)

