### PR TITLE
docs(ext/dynblock): recursive function call typo in detecting variables

### DIFF
--- a/ext/dynblock/README.md
+++ b/ext/dynblock/README.md
@@ -134,7 +134,7 @@ func walkVariables(node dynblock.WalkVariablesNode, schema *hcl.BodySchema) []hc
 			panic(fmt.Errorf("can't find schema for unknown block type %q", child.BlockTypeName))
 		}
 
-		vars = append(vars, testWalkAndAccumVars(child.Node, childSchema)...)
+		vars = append(vars, walkVariables(child.Node, childSchema)...)
 	}
 }
 ```


### PR DESCRIPTION
I'm studying HCL internals and when reading the docs for detecting variables in the `dynblock` package I got confused by the recursive function call but I noticed that for the depth-first, pre-order traversal the function name was wrong.

It's a small adjustment and I hope I can continue contributing more.

Thank you.