### PR TITLE
feat: return an `ExprSyntaxError` for invalid references that end in a dot

### DIFF
--- a/hclsyntax/parser_test.go
+++ b/hclsyntax/parser_test.go
@@ -2672,6 +2672,87 @@ block "valid" {}
 				},
 			},
 		},
+		{
+			"a = { b = c. }",
+			1,
+			&Body{
+				Attributes: Attributes{
+					"a": {
+						Name: "a",
+						Expr: &ObjectConsExpr{
+							Items: []ObjectConsItem{
+								{
+									KeyExpr: &ObjectConsKeyExpr{
+										Wrapped: &ScopeTraversalExpr{
+											Traversal: hcl.Traversal{
+												hcl.TraverseRoot{
+													Name: "b",
+													SrcRange: hcl.Range{
+														Start: hcl.Pos{Line: 1, Column: 7, Byte: 6},
+														End:   hcl.Pos{Line: 1, Column: 8, Byte: 7},
+													},
+												},
+											},
+											SrcRange: hcl.Range{
+												Start: hcl.Pos{Line: 1, Column: 7, Byte: 6},
+												End:   hcl.Pos{Line: 1, Column: 8, Byte: 7},
+											},
+										},
+									},
+									ValueExpr: &ExprSyntaxError{
+										Placeholder: cty.DynamicVal,
+										SrcRange: hcl.Range{
+											Start: hcl.Pos{Line: 1, Column: 11, Byte: 10},
+											End:   hcl.Pos{Line: 1, Column: 13, Byte: 12},
+										},
+										ParseDiags: hcl.Diagnostics{
+											{
+												Severity: hcl.DiagError,
+												Summary:  "Invalid attribute name",
+												Detail:   "An attribute name is required after a dot.",
+												Subject: &hcl.Range{
+													Start: hcl.Pos{Line: 1, Column: 14, Byte: 13},
+													End:   hcl.Pos{Line: 1, Column: 15, Byte: 14},
+												},
+											},
+										},
+									},
+								},
+							},
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 1, Column: 5, Byte: 4},
+								End:   hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							},
+							OpenRange: hcl.Range{
+								Start: hcl.Pos{Line: 1, Column: 5, Byte: 4},
+								End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+							},
+						},
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:   hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+						NameRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:   hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						},
+						EqualsRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 3, Byte: 2},
+							End:   hcl.Pos{Line: 1, Column: 4, Byte: 3},
+						},
+					},
+				},
+				Blocks: Blocks{},
+				SrcRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:   hcl.Pos{Line: 1, Column: 15, Byte: 14},
+				},
+				EndRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					End:   hcl.Pos{Line: 1, Column: 15, Byte: 14},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Return an `ExprSyntaxError` for invalid references that end in a dot (commonly occurs in editors for completions).

Detect value expressions of the `ExprSyntaxError` type when parsing object constructor expressions and use them to add an item to the result even though we skip parsing the object due to recovery after the invalid expression.

This allows the Terraform language server to support completions for object attributes after a dot was typed.
