### PR TITLE
Preserve marks when traversing unknown values

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -49,7 +49,7 @@ func Index(collection, key cty.Value, srcRange *Range) (cty.Value, Diagnostics) 
 	ty := collection.Type()
 	kty := key.Type()
 	if kty == cty.DynamicPseudoType || ty == cty.DynamicPseudoType {
-		return cty.DynamicVal, nil
+		return cty.DynamicVal.WithSameMarks(collection), nil
 	}
 
 	switch {
@@ -87,9 +87,9 @@ func Index(collection, key cty.Value, srcRange *Range) (cty.Value, Diagnostics) 
 		has, _ := collection.HasIndex(key).Unmark()
 		if !has.IsKnown() {
 			if ty.IsTupleType() {
-				return cty.DynamicVal, nil
+				return cty.DynamicVal.WithSameMarks(collection), nil
 			} else {
-				return cty.UnknownVal(ty.ElementType()), nil
+				return cty.UnknownVal(ty.ElementType()).WithSameMarks(collection), nil
 			}
 		}
 		if has.False() {
@@ -196,10 +196,10 @@ func Index(collection, key cty.Value, srcRange *Range) (cty.Value, Diagnostics) 
 			}
 		}
 		if !collection.IsKnown() {
-			return cty.DynamicVal, nil
+			return cty.DynamicVal.WithSameMarks(collection), nil
 		}
 		if !key.IsKnown() {
-			return cty.DynamicVal, nil
+			return cty.DynamicVal.WithSameMarks(collection), nil
 		}
 
 		key, _ = key.Unmark()
@@ -291,13 +291,13 @@ func GetAttr(obj cty.Value, attrName string, srcRange *Range) (cty.Value, Diagno
 		}
 
 		if !obj.IsKnown() {
-			return cty.UnknownVal(ty.AttributeType(attrName)), nil
+			return cty.UnknownVal(ty.AttributeType(attrName)).WithSameMarks(obj), nil
 		}
 
 		return obj.GetAttr(attrName), nil
 	case ty.IsMapType():
 		if !obj.IsKnown() {
-			return cty.UnknownVal(ty.ElementType()), nil
+			return cty.UnknownVal(ty.ElementType()).WithSameMarks(obj), nil
 		}
 
 		idx := cty.StringVal(attrName)
@@ -319,7 +319,7 @@ func GetAttr(obj cty.Value, attrName string, srcRange *Range) (cty.Value, Diagno
 
 		return obj.Index(idx), nil
 	case ty == cty.DynamicPseudoType:
-		return cty.DynamicVal, nil
+		return cty.DynamicVal.WithSameMarks(obj), nil
 	case ty.IsListType() && ty.ElementType().IsObjectType():
 		// It seems a common mistake to try to access attributes on a whole
 		// list of objects rather than on a specific individual element, so


### PR DESCRIPTION
When traversing an unknown value or a `DynamicVal`, the marks from that initial value must be preserved for HCL Index and GetAttr operations. This mirrors the behavior of `GetAttr` and `Index` when used directly the underlying cty values.