### PR TITLE
Better control of marks through conditional and for expressions

### DIFF
--- a/hclsyntax/expression_template_test.go
+++ b/hclsyntax/expression_template_test.go
@@ -318,14 +318,14 @@ trim`,
 			cty.UnknownVal(cty.String).Refine().NotNull().StringPrefixFull(strings.Repeat("_", 128)).NewValue(),
 			0,
 		},
-		{ // marks from uninterpolated values are ignored
+		{ // all marks are passed through to ensure result is always consistent
 			`hello%{ if false } ${target}%{ endif }`,
 			&hcl.EvalContext{
 				Variables: map[string]cty.Value{
 					"target": cty.StringVal("world").Mark("sensitive"),
 				},
 			},
-			cty.StringVal("hello"),
+			cty.StringVal("hello").Mark("sensitive"),
 			0,
 		},
 		{ // marks from interpolated values are passed through

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1144,6 +1144,49 @@ upper(
 			0,
 		},
 		{
+			`{ for k, v in things: k => v if k != unknown_secret }`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.MapVal(map[string]cty.Value{
+						"a": cty.True,
+						"b": cty.False,
+						"c": cty.False,
+					}),
+					"unknown_secret": cty.UnknownVal(cty.String).Mark("sensitive"),
+				},
+			},
+			cty.DynamicVal.Mark("sensitive"),
+			0,
+		},
+		{
+			`[ for v in things: v if v != unknown_secret ]`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.TupleVal([]cty.Value{
+						cty.StringVal("a"),
+						cty.StringVal("b"),
+					}),
+					"unknown_secret": cty.UnknownVal(cty.String).Mark("sensitive"),
+				},
+			},
+			cty.DynamicVal.Mark("sensitive"),
+			0,
+		},
+		{
+			`[ for v in things: v if v != secret ]`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"things": cty.TupleVal([]cty.Value{
+						cty.UnknownVal(cty.String).Mark("mark"),
+						cty.StringVal("b"),
+					}),
+					"secret": cty.StringVal("b").Mark("sensitive"),
+				},
+			},
+			cty.DynamicVal.WithMarks(cty.NewValueMarks("mark", "sensitive")),
+			0,
+		},
+		{
 			`[{name: "Steve"}, {name: "Ermintrude"}].*.name`,
 			nil,
 			cty.TupleVal([]cty.Value{

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -2175,7 +2175,7 @@ EOT
 					}).Mark("sensitive"),
 				},
 			},
-			cty.NumberIntVal(1),
+			cty.NumberIntVal(1).Mark("sensitive"),
 			0,
 		},
 		{ // auto-converts collection types


### PR DESCRIPTION
The unknown value paths within conditional and for expressions were not consistently retaining marks.

In the case of for expressions, an unknown collection would lose all marks. If we have the any marks from the collection we can always return those. If the expression contains a conditional include, we can also attempt to obtain the marks from that since the conditional impacts the total collection value, the marks must alway be included in the final result. This gives us a more complete unknown value, but it can never contain a comprehensive set of marks for all cases. If the collection is entirely unknown, we have no idea what the element value marks are going to be though, so the final known result could still always include marks we were not anticipating.

The conditional expressions are more straightforward to fix, but also more troublesome from Terraform's perspective because it represents a change in behavior. Previously, the marks for the true and false values were kept distinct and were not included at all if the result was unknown. This poses a problem when behavior is specified by marks on the values however, because the the behavior changes depending on whether the result is known or not. The only way to reconcile this with conditionals is to always combine all marks, which is what I've done here. The union of marks definitely makes logical sense when the condition is unknown, since we could have either set, but could be surprising for configurations which could never produce an unknown condition. 

The change in marks looks like so (using letters for variables and numbers for marks):

|  `x(1) ? y(2) : z(3)` | `x` Unknown | `x` True | `x` False
|----|----|----|----|
| before | `<unknown>()` | `y(2)` | `z(3)` |
| after | `<unknown>(1,2,3)` | `y(1,2,3)` | `z(1,2,3)` |

You can see here that if `1` represented "sensitive" as used in Terraform, the result which is derived from a sensitive value has no indication of that.  A case could be made that the y and z values should be `y(1,2)` and `z(1,3)`, but conditional expressions already need to unify the return type, so it feels natural that it should also unify the _meta_-type information like marks, making the results more consistent and predictable.