### PR TITLE
fix boolean short-circuit diagnostic handling

### DIFF
--- a/hclsyntax/expression_ops.go
+++ b/hclsyntax/expression_ops.go
@@ -242,9 +242,6 @@ func (e *BinaryOpExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 	lhsVal, lhsMarks := lhsVal.Unmark()
 	rhsVal, rhsMarks := rhsVal.Unmark()
 
-	// If we short-circuited above and still passed the type-check of RHS then
-	// we'll halt here and return the short-circuit result rather than actually
-	// executing the operation.
 	if e.Op.ShortCircuit != nil {
 		forceResult, diags := e.Op.ShortCircuit(lhsVal, rhsVal, lhsDiags, rhsDiags)
 		if forceResult != cty.NilVal {
@@ -256,6 +253,8 @@ func (e *BinaryOpExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 		}
 	}
 
+	diags = append(diags, lhsDiags...)
+	diags = append(diags, rhsDiags...)
 	if diags.HasErrors() {
 		// Don't actually try the call if we have errors, since the this will
 		// probably just produce confusing duplicate diagnostics.

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -2616,6 +2616,16 @@ func TestExpressionErrorMessages(t *testing.T) {
 			"Function calls not allowed",
 			`Functions may not be called here.`,
 		},
+		{
+			`map != null || map["key"] == "value"`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"map": cty.NullVal(cty.Map(cty.String)),
+				},
+			},
+			"Attempt to index null value",
+			`This value is null, so it does not have any indices.`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Follow up to #713.

A couple boolean expression tests were passing because diagnostics were accidentally dropped when there was no short-circuit return. Add a positive test for the diagnostics and make sure they are always collected from both sides of the expression.

The logic to drop diagnostics needed to be within the short-circuit implementations, where a good LHS unknown value (one without any errors) prevents further evaluation allowing us to optimistically skip the RHS diagnostics. This can be confusing, because the logic looked correct, but we need to remember that cty/hcl return an unknown value when faced with errors too, and part of the short-circuit logic is to selectively handle errors when possible.