### PR TITLE
Prevent diagnostic writes from panicking on marked values

### DIFF
--- a/diagnostic_text.go
+++ b/diagnostic_text.go
@@ -259,6 +259,8 @@ func (w *diagnosticTextWriter) valueStr(val cty.Value) string {
 		// Should never happen here because we should filter before we get
 		// in here, but we'll do something reasonable rather than panic.
 		return "(not yet known)"
+	case val.IsMarked():
+		return "(marked value)"
 	case ty == cty.Bool:
 		if val.True() {
 			return "true"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/hcl/issues/737

When the `DiagnosticTextWriter` writes out a diagnostic, if the diagnostic has an Expression and EvalContext, it will also write out the evaluation context in which the diagnostic occurred.

The `cty.Value` of the variable relevant to the expression will be rendered as a string by `valueStr`, but this does not take into account marked values and will cause a panic by `val.AsString()`, `val.LengthInt()`, etc.

This change prevents panics by always returning "(marked value)" for marked values in `valueStr`. Whether this is always appropriate is debatable, but it is better than the current situation, which causes panics.

---

This PR changes `valueStr`, but there is also an idea to change `WriteDiagnostic`. For instance, unknown values ​​will be returned as "(not yet known)" in `valueStr`, but `WriteDiagnostic` will prevent unknown values ​​from being rendered:
https://github.com/hashicorp/hcl/blob/561e19981c0187e1204f6e949aa839c5da12672b/diagnostic_text.go#L168-L170

I'd be happy to discuss here which one is more appropriate.

However, if you take this approach, you will need to adapt `traversalStr` as well.
https://github.com/hashicorp/hcl/blob/561e19981c0187e1204f6e949aa839c5da12672b/diagnostic_text.go#L237

**EDIT:** This is the same approach as Terraform.
https://github.com/hashicorp/terraform/blob/v1.5.7/internal/command/views/json/diagnostic.go#L400-L406