### PR TITLE
Skip marked values when writing diagnostics

### DIFF
--- a/diagnostic_text.go
+++ b/diagnostic_text.go
@@ -170,6 +170,9 @@ func (w *diagnosticTextWriter) WriteDiagnostic(diag *Diagnostic) error {
 					continue
 				case val.IsNull():
 					stmts = append(stmts, fmt.Sprintf("%s set to null", traversalStr))
+				case val.IsMarked():
+					// Skip the marked values as it is not clear here how they should be rendered.
+					continue
 				default:
 					stmts = append(stmts, fmt.Sprintf("%s as %s", traversalStr, w.valueStr(val)))
 				}

--- a/diagnostic_text_test.go
+++ b/diagnostic_text_test.go
@@ -157,6 +157,21 @@ Did you mean "pizzetta"?
 								Name: "boz",
 							},
 						},
+						{
+							TraverseRoot{
+								Name: "marked",
+							},
+						},
+						{
+							TraverseRoot{
+								Name: "null",
+							},
+						},
+						{
+							TraverseRoot{
+								Name: "unknown",
+							},
+						},
 					},
 				},
 				EvalContext: &EvalContext{
@@ -169,8 +184,11 @@ Did you mean "pizzetta"?
 						"bar": cty.ObjectVal(map[string]cty.Value{
 							"baz": cty.ListValEmpty(cty.String),
 						}),
-						"boz":    cty.NumberIntVal(5),
-						"unused": cty.True,
+						"boz":     cty.NumberIntVal(5),
+						"marked":  cty.StringVal("marked").Mark("x"),
+						"null":    cty.NullVal(cty.String),
+						"unknown": cty.UnknownVal(cty.String),
+						"unused":  cty.True,
 					},
 				},
 			},
@@ -181,7 +199,8 @@ Did you mean "pizzetta"?
 
 with bar.baz as empty list of string,
      boz as 5,
-     foo as "foo value".
+     foo as "foo value",
+     null set to null.
 
 This diagnostic includes an expression
 and an evalcontext.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/hcl/issues/737
Follow up of https://github.com/hashicorp/hcl/pull/738

When the `DiagnosticTextWriter` writes out a diagnostic, if the diagnostic has an Expression and EvalContext, it will also write out the evaluation context in which the diagnostic occurred.

The `cty.Value` of the variable relevant to the expression will be rendered as a string by `valueStr`, but calls to `AsString` or `LengthInt` here will panic on marked values.

It is not clear how HCL should represent such marks, so we skip the marked values from the additional context as a general-purpose diagnostic writer.