### PR TITLE
test_suite: refactor schema validation of diagnostic file range, pos

### DIFF
--- a/cmd/hclspecsuite/test_file.go
+++ b/cmd/hclspecsuite/test_file.go
@@ -304,7 +304,7 @@ func (r *Runner) decodeRangeFromBody(body hcl.Body) (hcl.Range, hcl.Body, hcl.Di
 	rangeBody, remain, moreDiags := body.PartialContent(testFileRangeSchema)
 
 	diags = append(diags, moreDiags...)
-	if moreDiags.HasErrors() {
+	if rangeBody == nil {
 		return hcl.Range{}, nil, diags
 	}
 


### PR DESCRIPTION
With this refactor, the variables `testFileRangeSchema` and `testFilePosSchema` are no longer unused.