### PR TITLE
suppress and fix lint errors by unused

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,4 +102,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          args: --enable-only=staticcheck
+          args: --enable-only=staticcheck,unused # this is temporary until we can fix the other issues

--- a/ext/transform/transform_test.go
+++ b/ext/transform/transform_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 // Assert that deepWrapper implements Body
+//
+//nolint:unused
 var deepWrapperIsBody hcl.Body = deepWrapper{}
 
 func TestDeep(t *testing.T) {

--- a/gohcl/types.go
+++ b/gohcl/types.go
@@ -14,6 +14,8 @@ var victimBody hcl.Body
 
 var exprType = reflect.TypeOf(&victimExpr).Elem()
 var bodyType = reflect.TypeOf(&victimBody).Elem()
+
+//nolint:unused
 var blockType = reflect.TypeOf((*hcl.Block)(nil))
 var attrType = reflect.TypeOf((*hcl.Attribute)(nil))
 var attrsType = reflect.TypeOf(hcl.Attributes(nil))

--- a/hclsyntax/scan_string_lit.go
+++ b/hclsyntax/scan_string_lit.go
@@ -109,8 +109,11 @@ var _hclstrtok_eof_actions []byte = []byte{
 	3,
 }
 
+//nolint:unused
 const hclstrtok_start int = 4
 const hclstrtok_first_final int = 4
+
+//nolint:unused
 const hclstrtok_error int = 0
 
 const hclstrtok_en_quoted int = 10

--- a/hclsyntax/scan_tokens.go
+++ b/hclsyntax/scan_tokens.go
@@ -4207,10 +4207,14 @@ var _hcltok_eof_trans []int16 = []int16{
 	1513, 1513, 1513, 1513, 1513, 1513, 1513,
 }
 
+//nolint:unused
 const hcltok_start int = 1459
 const hcltok_first_final int = 1459
+
+//nolint:unused
 const hcltok_error int = 0
 
+//nolint:unused
 const hcltok_en_stringTemplate int = 1510
 const hcltok_en_heredocTemplate int = 1524
 const hcltok_en_bareTemplate int = 1535

--- a/hclsyntax/structure.go
+++ b/hclsyntax/structure.go
@@ -42,6 +42,8 @@ type Body struct {
 }
 
 // Assert that *Body implements hcl.Body
+//
+//nolint:unused
 var assertBodyImplBody hcl.Body = &Body{}
 
 func (b *Body) walkChildNodes(w internalWalkFunc) {

--- a/hcltest/mock_test.go
+++ b/hcltest/mock_test.go
@@ -13,8 +13,13 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+//nolint:unused
 var mockBodyIsBody hcl.Body = mockBody{}
+
+//nolint:unused
 var mockExprLiteralIsExpr hcl.Expression = mockExprLiteral{}
+
+//nolint:unused
 var mockExprVariableIsExpr hcl.Expression = mockExprVariable("")
 
 func TestMockBodyPartialContent(t *testing.T) {

--- a/hclwrite/ast.go
+++ b/hclwrite/ast.go
@@ -54,7 +54,6 @@ func (f *File) Bytes() []byte {
 type comments struct {
 	leafNode
 
-	parent *node
 	tokens Tokens
 }
 
@@ -71,8 +70,7 @@ func (c *comments) BuildTokens(to Tokens) Tokens {
 type identifier struct {
 	leafNode
 
-	parent *node
-	token  *Token
+	token *Token
 }
 
 func newIdentifier(token *Token) *identifier {
@@ -92,8 +90,7 @@ func (i *identifier) hasName(name string) bool {
 type number struct {
 	leafNode
 
-	parent *node
-	token  *Token
+	token *Token
 }
 
 func newNumber(token *Token) *number {
@@ -109,7 +106,6 @@ func (n *number) BuildTokens(to Tokens) Tokens {
 type quoted struct {
 	leafNode
 
-	parent *node
 	tokens Tokens
 }
 

--- a/json/parser.go
+++ b/json/parser.go
@@ -101,6 +101,7 @@ func parseValue(p *peeker) (node, hcl.Diagnostics) {
 	}
 }
 
+//nolint:unused
 func tokenCanStartValue(tok token) bool {
 	switch tok.Type {
 	case tokenBraceO, tokenBrackO, tokenNumber, tokenString, tokenKeyword:


### PR DESCRIPTION
The majority of unused declarations were one of 3 types:
  - Global constants or sentinel variables. These were untouched becuse they serve as documentation and may become useful in the future.
  - Variable declarations to assert a struct implements an interface. These are compile time safety nets and were also ountouched.
  - Runtime function
  - Unused fields in structs. These were removed to reduce overall since they serve no purpose and at best increase memory consumption and at worst make such structs more confusing to the reader.

There was also an undocumented private function that was removed.  It was straightforward and can be reimplemented if need be.