### PR TITLE
cherry-pick Vault changes to Nomad HCL1 branch

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -21,7 +21,18 @@ var (
 // Unmarshal accepts a byte slice as input and writes the
 // data to the value pointed to by v.
 func Unmarshal(bs []byte, v interface{}) error {
-	root, err := parse(bs)
+	root, err := parse(bs, false)
+	if err != nil {
+		return err
+	}
+
+	return DecodeObject(v, root)
+}
+
+// UnmarshalErrorOnDuplicates accepts a byte slice as input and writes the
+// data to the value pointed to by v but errors on duplicate attribute key.
+func UnmarshalErrorOnDuplicates(bs []byte, v interface{}) error {
+	root, err := parse(bs, true)
 	if err != nil {
 		return err
 	}
@@ -32,7 +43,19 @@ func Unmarshal(bs []byte, v interface{}) error {
 // Decode reads the given input and decodes it into the structure
 // given by `out`.
 func Decode(out interface{}, in string) error {
-	obj, err := Parse(in)
+	return decode(out, in, false)
+}
+
+// DecodeErrorOnDuplicates reads the given input and decodes it into the structure but errrors on duplicate attribute key
+// given by `out`.
+func DecodeErrorOnDuplicates(out interface{}, in string) error {
+	return decode(out, in, true)
+}
+
+// decode reads the given input and decodes it into the structure given by `out`.
+// takes in a boolean to determine if it should error on duplicate attribute
+func decode(out interface{}, in string, errorOnDuplicateAtributes bool) error {
+	obj, err := parse([]byte(in), errorOnDuplicateAtributes)
 	if err != nil {
 		return err
 	}
@@ -397,6 +420,7 @@ func (d *decoder) decodeMap(name string, node ast.Node, result reflect.Value) er
 
 	// Set the final map if we can
 	set.Set(resultMap)
+
 	return nil
 }
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -35,6 +35,13 @@ func TestDecode_interface(t *testing.T) {
 			},
 		},
 		{
+			"basic_duplicates.hcl",
+			false,
+			map[string]interface{}{
+				"foo": "${file(\"bing/bong.txt\")}",
+			},
+		},
+		{
 			"empty.hcl",
 			false,
 			map[string]interface{}{
@@ -438,6 +445,49 @@ func TestDecode_interface(t *testing.T) {
 
 			var v interface{}
 			err = Unmarshal(d, &v)
+			if (err != nil) != tc.Err {
+				t.Fatalf("Input: %s\n\nError: %s", tc.File, err)
+			}
+
+			if !reflect.DeepEqual(v, tc.Out) {
+				t.Fatalf("Input: %s. Actual, Expected.\n\n%#v\n\n%#v", tc.File, out, tc.Out)
+			}
+		})
+	}
+}
+
+func TestDecodeErrorOnDuplicates_interface(t *testing.T) {
+	cases := []struct {
+		File string
+		Err  bool
+		Out  interface{}
+	}{
+		{
+			"basic_duplicates.hcl",
+			true,
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.File, func(t *testing.T) {
+			d, err := ioutil.ReadFile(filepath.Join(fixtureDir, tc.File))
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			var out interface{}
+			err = DecodeErrorOnDuplicates(&out, string(d))
+			if (err != nil) != tc.Err {
+				t.Fatalf("Input: %s\n\nError: %s", tc.File, err)
+			}
+
+			if !reflect.DeepEqual(out, tc.Out) {
+				t.Fatalf("Input: %s. Actual, Expected.\n\n%#v\n\n%#v", tc.File, out, tc.Out)
+			}
+
+			var v interface{}
+			err = UnmarshalErrorOnDuplicates(d, &v)
 			if (err != nil) != tc.Err {
 				t.Fatalf("Input: %s\n\nError: %s", tc.File, err)
 			}

--- a/hcl/parser/parser.go
+++ b/hcl/parser/parser.go
@@ -27,22 +27,35 @@ type Parser struct {
 	enableTrace bool
 	indent      int
 	n           int // buffer size (max = 1)
+
+	errorOnDuplicateKeys bool
 }
 
-func newParser(src []byte) *Parser {
+func newParser(src []byte, errorOnDuplicateKeys bool) *Parser {
 	return &Parser{
-		sc: scanner.New(src),
+		sc:                   scanner.New(src),
+		errorOnDuplicateKeys: errorOnDuplicateKeys,
 	}
 }
 
 // Parse returns the fully parsed source and returns the abstract syntax tree.
 func Parse(src []byte) (*ast.File, error) {
+	return parse(src, true)
+}
+
+// Parse returns the fully parsed source and returns the abstract syntax tree.
+func ParseDontErrorOnDuplicateKeys(src []byte) (*ast.File, error) {
+	return parse(src, false)
+}
+
+// Parse returns the fully parsed source and returns the abstract syntax tree.
+func parse(src []byte, errorOnDuplicateKeys bool) (*ast.File, error) {
 	// normalize all line endings
 	// since the scanner and output only work with "\n" line endings, we may
 	// end up with dangling "\r" characters in the parsed data.
 	src = bytes.Replace(src, []byte("\r\n"), []byte("\n"), -1)
 
-	p := newParser(src)
+	p := newParser(src, errorOnDuplicateKeys)
 	return p.Parse()
 }
 
@@ -65,6 +78,7 @@ func (p *Parser) Parse() (*ast.File, error) {
 	}
 
 	f.Comments = p.comments
+
 	return f, nil
 }
 

--- a/hcl/parser/parser_test.go
+++ b/hcl/parser/parser_test.go
@@ -28,7 +28,7 @@ func TestType(t *testing.T) {
 	}
 
 	for _, l := range literals {
-		p := newParser([]byte(l.src))
+		p := newParser([]byte(l.src), true)
 		item, err := p.objectItem()
 		if err != nil {
 			t.Error(err)
@@ -78,7 +78,7 @@ EOF
 	}
 
 	for _, l := range literals {
-		p := newParser([]byte(l.src))
+		p := newParser([]byte(l.src), true)
 		item, err := p.objectItem()
 		if err != nil {
 			t.Error(err)
@@ -105,7 +105,7 @@ func TestListOfMaps(t *testing.T) {
     {key = "bar"},
     {key = "baz", key2 = "qux"},
   ]`
-	p := newParser([]byte(src))
+	p := newParser([]byte(src), true)
 
 	file, err := p.Parse()
 	if err != nil {
@@ -139,7 +139,7 @@ func TestListOfMaps_requiresComma(t *testing.T) {
     {key = "bar"}
     {key = "baz"}
   ]`
-	p := newParser([]byte(src))
+	p := newParser([]byte(src), true)
 
 	_, err := p.Parse()
 	if err == nil {
@@ -169,7 +169,7 @@ func TestListType_leadComment(t *testing.T) {
 	}
 
 	for _, l := range literals {
-		p := newParser([]byte(l.src))
+		p := newParser([]byte(l.src), true)
 		item, err := p.objectItem()
 		if err != nil {
 			t.Fatal(err)
@@ -220,7 +220,7 @@ func TestListType_lineComment(t *testing.T) {
 	}
 
 	for _, l := range literals {
-		p := newParser([]byte(l.src))
+		p := newParser([]byte(l.src), true)
 		item, err := p.objectItem()
 		if err != nil {
 			t.Fatal(err)
@@ -309,7 +309,7 @@ func TestObjectType(t *testing.T) {
 	for _, l := range literals {
 		t.Logf("Source: %s", l.src)
 
-		p := newParser([]byte(l.src))
+		p := newParser([]byte(l.src), true)
 		// p.enableTrace = true
 		item, err := p.objectItem()
 		if err != nil {
@@ -355,7 +355,7 @@ func TestObjectKey(t *testing.T) {
 	}
 
 	for _, k := range keys {
-		p := newParser([]byte(k.src))
+		p := newParser([]byte(k.src), true)
 		keys, err := p.objectKey()
 		if err != nil {
 			t.Fatal(err)
@@ -379,7 +379,7 @@ func TestObjectKey(t *testing.T) {
 	}
 
 	for _, k := range errKeys {
-		p := newParser([]byte(k.src))
+		p := newParser([]byte(k.src), true)
 		_, err := p.objectKey()
 		if err == nil {
 			t.Errorf("case '%s' should give an error", k.src)
@@ -398,7 +398,7 @@ func TestCommentGroup(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.src, func(t *testing.T) {
-			p := newParser([]byte(tc.src))
+			p := newParser([]byte(tc.src), true)
 			file, err := p.Parse()
 			if err != nil {
 				t.Fatalf("parse error: %s", err)

--- a/parse.go
+++ b/parse.go
@@ -12,17 +12,20 @@ import (
 //
 // Input can be either JSON or HCL
 func ParseBytes(in []byte) (*ast.File, error) {
-	return parse(in)
+	return parse(in, true)
 }
 
 // ParseString accepts input as a string and returns ast tree.
 func ParseString(input string) (*ast.File, error) {
-	return parse([]byte(input))
+	return parse([]byte(input), true)
 }
 
-func parse(in []byte) (*ast.File, error) {
+func parse(in []byte, errorOnDuplicateKeys bool) (*ast.File, error) {
 	switch lexMode(in) {
 	case lexModeHcl:
+		if !errorOnDuplicateKeys {
+			return hclParser.ParseDontErrorOnDuplicateKeys(in)
+		}
 		return hclParser.Parse(in)
 	case lexModeJson:
 		return jsonParser.Parse(in)
@@ -35,5 +38,5 @@ func parse(in []byte) (*ast.File, error) {
 //
 // The input format can be either HCL or JSON.
 func Parse(input string) (*ast.File, error) {
-	return parse([]byte(input))
+	return parse([]byte(input), true)
 }

--- a/test-fixtures/basic_duplicates.hcl
+++ b/test-fixtures/basic_duplicates.hcl
@@ -1,0 +1,2 @@
+foo = "bar"
+foo = "${file("bing/bong.txt")}"


### PR DESCRIPTION
For reasons of backwards compatibility, Nomad uses an older branch of HCL1 ([`v1.0.1-nomad`](https://github.com/hashicorp/hcl/tree/v1.0.1-nomad)) and HCL2 ([`v2.20.2-nomad-1`](https://github.com/hashicorp/hcl/tree/v2.20.2-nomad-1)), and backports a limited set of changes to those branches. 

But the Vault API also has their own HCL1 branch, currently tagged as [`v1.0.1-vault-7`](https://github.com/hashicorp/hcl/tree/v1.0.1-vault-7). Normally this isn't a problem because Nomad pins to our own branch and we don't call any of the Vault API package's HCL code anyways. But in https://github.com/hashicorp/hcl/pull/707 some functions were changed that break our build (ref https://github.com/hashicorp/nomad/pull/26006) unless we backport them.

This PR cherry-picks the Vault HCL1 changes to the Nomad HCL1 branch. I've tested this against our configuration parsing tests in Nomad and that fixes the build.