### PR TITLE
chore: try using publicly available version of copywrite to manage new copyright header content

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -2,6 +2,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
+  copyright_holder = "IBM Corp. 2014, 2025"
   copyright_year = 2014
 
   # (OPTIONAL) A list of globs that should not have copyright/license headers.


### PR DESCRIPTION
This approach is likely to break once a year when the current year needs to be incremented (?)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

Exploring how to use the public copywrite tool to address copyright header changes.

## Related Issue

https://github.com/hashicorp/hcl/pull/770

## How Has This Been Tested?

Deleting a header comment from a file and then running:

```
copywrite header
```
