### PR TITLE
update automation for 2025

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -2,7 +2,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2014
+  copyright_holder = "IBM Corp. 2014, 2025" // copyright_year doesn't accept multiple entries
 
   # (OPTIONAL) A list of globs that should not have copyright/license headers.
   # Supports doublestar glob patterns for more flexibility in defining which


### PR DESCRIPTION
We're somewhat stuck in an awkward position in that the new copyright header tool (that can automatically update all files, and also automatically handles the {firstyear, lastyear} style header) isn't publicly available as a binary.  This PR updates our automation so at least new files will get the correct header and it can continue to run in automation. 

We will need to update this file in 2026, and run the fork of the copyright tool (built locally) to update these files with the correct year. Ideally by then we can also just use that tool directly (in automation), instead of running two tools, but that's up to the team that owns the tool.

 