### PR TITLE
add partially complete items in nested object cons structures on error

### DIFF
--- a/hclsyntax/parser.go
+++ b/hclsyntax/parser.go
@@ -1441,7 +1441,7 @@ func (p *parser) parseObjectCons() (Expression, hcl.Diagnostics) {
 		}
 
 		// Wrapping parens are not explicitly represented in the AST, but
-		// we want to use them here to disambiguate intepreting a mapping
+		// we want to use them here to disambiguate interpreting a mapping
 		// key as a full expression rather than just a name, and so
 		// we'll remember this was present and use it to force the
 		// behavior of our final ObjectConsKeyExpr.
@@ -1521,29 +1521,18 @@ func (p *parser) parseObjectCons() (Expression, hcl.Diagnostics) {
 
 		value, valueDiags := p.ParseExpression()
 		diags = append(diags, valueDiags...)
+		items = append(items, ObjectConsItem{
+			KeyExpr:   key,
+			ValueExpr: value,
+		})
 
 		if p.recovery && valueDiags.HasErrors() {
-			// If the value is an ExprSyntaxError, we can add an item with it, even though we will recover afterwards
-			// This allows downstream consumers to still retrieve this first invalid item, even though following items
-			// won't be parsed. This is useful for supplying completions.
-			if exprSyntaxError, ok := value.(*ExprSyntaxError); ok {
-				items = append(items, ObjectConsItem{
-					KeyExpr:   key,
-					ValueExpr: exprSyntaxError,
-				})
-			}
-
 			// If expression parsing failed then we are probably in a strange
 			// place in the token stream, so we'll bail out and try to reset
 			// to after our closing brace to allow parsing to continue.
 			close = p.recover(TokenCBrace)
 			break
 		}
-
-		items = append(items, ObjectConsItem{
-			KeyExpr:   key,
-			ValueExpr: value,
-		})
 
 		next = p.Peek()
 		if next.Type == TokenCBrace {

--- a/hclsyntax/parser_test.go
+++ b/hclsyntax/parser_test.go
@@ -2806,6 +2806,34 @@ attr2 = "foo"
 							Name: "object",
 							Args: []Expression{
 								&ObjectConsExpr{
+									Items: []ObjectConsItem{
+										{
+											KeyExpr: &ObjectConsKeyExpr{
+												Wrapped: &ScopeTraversalExpr{
+													Traversal: hcl.Traversal{
+														hcl.TraverseRoot{
+															Name: "foo",
+															SrcRange: hcl.Range{
+																Start: hcl.Pos{Line: 1, Column: 17, Byte: 16},
+																End:   hcl.Pos{Line: 1, Column: 20, Byte: 19},
+															},
+														},
+													},
+													SrcRange: hcl.Range{
+														Start: hcl.Pos{Line: 1, Column: 17, Byte: 16},
+														End:   hcl.Pos{Line: 1, Column: 20, Byte: 19},
+													},
+												},
+											},
+											ValueExpr: &LiteralValueExpr{
+												Val: cty.DynamicVal,
+												SrcRange: hcl.Range{
+													Start: hcl.Pos{Line: 1, Column: 23, Byte: 22},
+													End:   hcl.Pos{Line: 1, Column: 24, Byte: 23},
+												},
+											},
+										},
+									},
 									SrcRange: hcl.Range{
 										Start: hcl.Pos{Line: 1, Column: 15, Byte: 14},
 										End:   hcl.Pos{Line: 1, Column: 24, Byte: 23},
@@ -3175,6 +3203,34 @@ attr2 = "foo"
 										Name: "object",
 										Args: []Expression{
 											&ObjectConsExpr{
+												Items: []ObjectConsItem{
+													{
+														KeyExpr: &ObjectConsKeyExpr{
+															Wrapped: &ScopeTraversalExpr{
+																Traversal: hcl.Traversal{
+																	hcl.TraverseRoot{
+																		Name: "foo",
+																		SrcRange: hcl.Range{
+																			Start: hcl.Pos{Line: 2, Column: 19, Byte: 34},
+																			End:   hcl.Pos{Line: 2, Column: 22, Byte: 37},
+																		},
+																	},
+																},
+																SrcRange: hcl.Range{
+																	Start: hcl.Pos{Line: 2, Column: 19, Byte: 34},
+																	End:   hcl.Pos{Line: 2, Column: 22, Byte: 37},
+																},
+															},
+														},
+														ValueExpr: &LiteralValueExpr{
+															Val: cty.DynamicVal,
+															SrcRange: hcl.Range{
+																Start: hcl.Pos{Line: 2, Column: 24, Byte: 39},
+																End:   hcl.Pos{Line: 3, Column: 1, Byte: 40},
+															},
+														},
+													},
+												},
 												SrcRange: hcl.Range{
 													Start: hcl.Pos{Line: 2, Column: 17, Byte: 32},
 													End:   hcl.Pos{Line: 3, Column: 1, Byte: 40},
@@ -3267,6 +3323,34 @@ attr2 = "foo"
 										Name: "object",
 										Args: []Expression{
 											&ObjectConsExpr{
+												Items: []ObjectConsItem{
+													{
+														KeyExpr: &ObjectConsKeyExpr{
+															Wrapped: &ScopeTraversalExpr{
+																Traversal: hcl.Traversal{
+																	hcl.TraverseRoot{
+																		Name: "foo",
+																		SrcRange: hcl.Range{
+																			Start: hcl.Pos{Line: 2, Column: 19, Byte: 34},
+																			End:   hcl.Pos{Line: 2, Column: 22, Byte: 37},
+																		},
+																	},
+																},
+																SrcRange: hcl.Range{
+																	Start: hcl.Pos{Line: 2, Column: 19, Byte: 34},
+																	End:   hcl.Pos{Line: 2, Column: 22, Byte: 37},
+																},
+															},
+														},
+														ValueExpr: &LiteralValueExpr{
+															Val: cty.DynamicVal,
+															SrcRange: hcl.Range{
+																Start: hcl.Pos{Line: 2, Column: 25, Byte: 40},
+																End:   hcl.Pos{Line: 2, Column: 26, Byte: 41},
+															},
+														},
+													},
+												},
 												SrcRange: hcl.Range{
 													Start: hcl.Pos{Line: 2, Column: 17, Byte: 32},
 													End:   hcl.Pos{Line: 2, Column: 26, Byte: 41},
@@ -3359,6 +3443,34 @@ attr2 = "foo"
 										Name: "object",
 										Args: []Expression{
 											&ObjectConsExpr{
+												Items: []ObjectConsItem{
+													{
+														KeyExpr: &ObjectConsKeyExpr{
+															Wrapped: &ScopeTraversalExpr{
+																Traversal: hcl.Traversal{
+																	hcl.TraverseRoot{
+																		Name: "foo",
+																		SrcRange: hcl.Range{
+																			Start: hcl.Pos{Line: 2, Column: 19, Byte: 34},
+																			End:   hcl.Pos{Line: 2, Column: 22, Byte: 37},
+																		},
+																	},
+																},
+																SrcRange: hcl.Range{
+																	Start: hcl.Pos{Line: 2, Column: 19, Byte: 34},
+																	End:   hcl.Pos{Line: 2, Column: 22, Byte: 37},
+																},
+															},
+														},
+														ValueExpr: &LiteralValueExpr{
+															Val: cty.DynamicVal,
+															SrcRange: hcl.Range{
+																Start: hcl.Pos{Line: 2, Column: 25, Byte: 40},
+																End:   hcl.Pos{Line: 2, Column: 26, Byte: 41},
+															},
+														},
+													},
+												},
 												SrcRange: hcl.Range{
 													Start: hcl.Pos{Line: 2, Column: 17, Byte: 32},
 													End:   hcl.Pos{Line: 2, Column: 26, Byte: 41},
@@ -3456,6 +3568,34 @@ attr2 = "foo"
 										Name: "object",
 										Args: []Expression{
 											&ObjectConsExpr{
+												Items: []ObjectConsItem{
+													{
+														KeyExpr: &ObjectConsKeyExpr{
+															Wrapped: &ScopeTraversalExpr{
+																Traversal: hcl.Traversal{
+																	hcl.TraverseRoot{
+																		Name: "foo",
+																		SrcRange: hcl.Range{
+																			Start: hcl.Pos{Line: 3, Column: 5, Byte: 38},
+																			End:   hcl.Pos{Line: 3, Column: 8, Byte: 41},
+																		},
+																	},
+																},
+																SrcRange: hcl.Range{
+																	Start: hcl.Pos{Line: 3, Column: 5, Byte: 38},
+																	End:   hcl.Pos{Line: 3, Column: 8, Byte: 41},
+																},
+															},
+														},
+														ValueExpr: &LiteralValueExpr{
+															Val: cty.DynamicVal,
+															SrcRange: hcl.Range{
+																Start: hcl.Pos{Line: 3, Column: 10, Byte: 43},
+																End:   hcl.Pos{Line: 4, Column: 1, Byte: 44},
+															},
+														},
+													},
+												},
 												SrcRange: hcl.Range{
 													Start: hcl.Pos{Line: 2, Column: 17, Byte: 32},
 													End:   hcl.Pos{Line: 5, Column: 1, Byte: 45},
@@ -3553,6 +3693,34 @@ another_block {
 										Name: "object",
 										Args: []Expression{
 											&ObjectConsExpr{
+												Items: []ObjectConsItem{
+													{
+														KeyExpr: &ObjectConsKeyExpr{
+															Wrapped: &ScopeTraversalExpr{
+																Traversal: hcl.Traversal{
+																	hcl.TraverseRoot{
+																		Name: "foo",
+																		SrcRange: hcl.Range{
+																			Start: hcl.Pos{Line: 3, Column: 5, Byte: 38},
+																			End:   hcl.Pos{Line: 3, Column: 8, Byte: 41},
+																		},
+																	},
+																},
+																SrcRange: hcl.Range{
+																	Start: hcl.Pos{Line: 3, Column: 5, Byte: 38},
+																	End:   hcl.Pos{Line: 3, Column: 8, Byte: 41},
+																},
+															},
+														},
+														ValueExpr: &LiteralValueExpr{
+															Val: cty.DynamicVal,
+															SrcRange: hcl.Range{
+																Start: hcl.Pos{Line: 3, Column: 10, Byte: 43},
+																End:   hcl.Pos{Line: 4, Column: 1, Byte: 44},
+															},
+														},
+													},
+												},
 												SrcRange: hcl.Range{
 													Start: hcl.Pos{Line: 2, Column: 17, Byte: 32},
 													End:   hcl.Pos{Line: 8, Column: 1, Byte: 64},
@@ -3647,6 +3815,34 @@ another_block {
 										Name: "object",
 										Args: []Expression{
 											&ObjectConsExpr{
+												Items: []ObjectConsItem{
+													{
+														KeyExpr: &ObjectConsKeyExpr{
+															Wrapped: &ScopeTraversalExpr{
+																Traversal: hcl.Traversal{
+																	hcl.TraverseRoot{
+																		Name: "foo",
+																		SrcRange: hcl.Range{
+																			Start: hcl.Pos{Line: 3, Column: 5, Byte: 38},
+																			End:   hcl.Pos{Line: 3, Column: 8, Byte: 41},
+																		},
+																	},
+																},
+																SrcRange: hcl.Range{
+																	Start: hcl.Pos{Line: 3, Column: 5, Byte: 38},
+																	End:   hcl.Pos{Line: 3, Column: 8, Byte: 41},
+																},
+															},
+														},
+														ValueExpr: &LiteralValueExpr{
+															Val: cty.DynamicVal,
+															SrcRange: hcl.Range{
+																Start: hcl.Pos{Line: 3, Column: 10, Byte: 43},
+																End:   hcl.Pos{Line: 4, Column: 1, Byte: 44},
+															},
+														},
+													},
+												},
 												SrcRange: hcl.Range{
 													Start: hcl.Pos{Line: 2, Column: 17, Byte: 32},
 													End:   hcl.Pos{Line: 4, Column: 4, Byte: 47},
@@ -3741,6 +3937,34 @@ another_block {
 										Name: "object",
 										Args: []Expression{
 											&ObjectConsExpr{
+												Items: []ObjectConsItem{
+													{
+														KeyExpr: &ObjectConsKeyExpr{
+															Wrapped: &ScopeTraversalExpr{
+																Traversal: hcl.Traversal{
+																	hcl.TraverseRoot{
+																		Name: "foo",
+																		SrcRange: hcl.Range{
+																			Start: hcl.Pos{Line: 3, Column: 5, Byte: 38},
+																			End:   hcl.Pos{Line: 3, Column: 8, Byte: 41},
+																		},
+																	},
+																},
+																SrcRange: hcl.Range{
+																	Start: hcl.Pos{Line: 3, Column: 5, Byte: 38},
+																	End:   hcl.Pos{Line: 3, Column: 8, Byte: 41},
+																},
+															},
+														},
+														ValueExpr: &LiteralValueExpr{
+															Val: cty.DynamicVal,
+															SrcRange: hcl.Range{
+																Start: hcl.Pos{Line: 3, Column: 10, Byte: 43},
+																End:   hcl.Pos{Line: 4, Column: 1, Byte: 44},
+															},
+														},
+													},
+												},
 												SrcRange: hcl.Range{
 													Start: hcl.Pos{Line: 2, Column: 17, Byte: 32},
 													End:   hcl.Pos{Line: 4, Column: 4, Byte: 47},
@@ -3823,6 +4047,7 @@ another_block {
 		cmpopts.IgnoreUnexported(FunctionCallExpr{}),
 		cmpopts.IgnoreUnexported(Body{}),
 		cmpopts.IgnoreUnexported(cty.Value{}),
+		cmpopts.IgnoreUnexported(hcl.TraverseRoot{}),
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {


### PR DESCRIPTION
## Description

As issue #597 notes, the nested structure of ObjectCons is not preserved when there is an error in processing the inner object.

This fixes the issue by unconditionally adding the inner item as opposed to only adding it for certain types of errors. This is the exact same processing as is done for tuple cons parsing.

Some unit tests for failure cases  broke as a result and have been updated to the new structures that will be written.

## Context

I've written an [HCL based DSL for processing resources ](https://github.com/crossplane-contrib/function-hcl/blob/main/spec.md) for [Crossplane](https://www.crossplane.io/) use. I'm writing a language server for this.

In this DSL, the resource definition is captured as an object value of a `body` attribute, which means that the entire resource is one object as opposed to Terraform where this is all nested blocks and attributes.

So while object cons recovery is relatively a nice-to-have feature for the Terraform language server given that such structures are few and far-between, my language server is dead in the water without this fix.

Please let me know how I can move this forward.

## Related Issue

Issue #597 

## How Has This Been Tested?

Extensively tested manually for the language server I'm writing. This fix does not change behavior when the HCL is well-formed.
