### PR TITLE
Set CloseBraceRange to last label in error-recovered blocks

### DIFF
--- a/hclsyntax/parser.go
+++ b/hclsyntax/parser.go
@@ -234,7 +234,6 @@ func (p *parser) parseSingleAttrBody(end TokenType) (*Body, hcl.Diagnostics) {
 			End:      attr.SrcRange.End,
 		},
 	}, diags
-
 }
 
 func (p *parser) finishParsingBodyAttribute(ident Token, singleLine bool) (Node, hcl.Diagnostics) {
@@ -295,7 +294,7 @@ func (p *parser) finishParsingBodyAttribute(ident Token, singleLine bool) (Node,
 }
 
 func (p *parser) finishParsingBodyBlock(ident Token) (Node, hcl.Diagnostics) {
-	var blockType = string(ident.Bytes)
+	blockType := string(ident.Bytes)
 	var diags hcl.Diagnostics
 	var labels []string
 	var labelRanges []hcl.Range
@@ -359,6 +358,16 @@ Token:
 
 			p.recoverAfterBodyItem()
 
+			// Use the last label range as the CloseBraceRange placeholder so that
+			// Block.Range() covers the full block header including labels.
+			// Without this, the block range only spans the type keyword,
+			// causing position-based lookups like OutermostBlockAtPos to
+			// miss positions within the labels.
+			endRange := ident.Range
+			if len(labelRanges) > 0 {
+				endRange = labelRanges[len(labelRanges)-1]
+			}
+
 			return &Block{
 				Type:   blockType,
 				Labels: labels,
@@ -370,7 +379,7 @@ Token:
 				TypeRange:       ident.Range,
 				LabelRanges:     labelRanges,
 				OpenBraceRange:  ident.Range, // placeholder
-				CloseBraceRange: ident.Range, // placeholder
+				CloseBraceRange: endRange,    // placeholder
 			}, diags
 		}
 	}

--- a/hclsyntax/parser_test.go
+++ b/hclsyntax/parser_test.go
@@ -428,8 +428,8 @@ block "valid" {}
 							End:   hcl.Pos{Line: 2, Column: 6, Byte: 6},
 						},
 						CloseBraceRange: hcl.Range{
-							Start: hcl.Pos{Line: 2, Column: 1, Byte: 1},
-							End:   hcl.Pos{Line: 2, Column: 6, Byte: 6},
+							Start: hcl.Pos{Line: 2, Column: 7, Byte: 7},
+							End:   hcl.Pos{Line: 2, Column: 16, Byte: 16},
 						},
 					},
 
@@ -2446,8 +2446,8 @@ block "valid" {}
 							End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
 						},
 						CloseBraceRange: hcl.Range{
-							Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
-							End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+							Start: hcl.Pos{Line: 1, Column: 33, Byte: 32},
+							End:   hcl.Pos{Line: 1, Column: 37, Byte: 36},
 						},
 					},
 				},

--- a/hclsyntax/structure_at_pos_test.go
+++ b/hclsyntax/structure_at_pos_test.go
@@ -122,6 +122,27 @@ func TestBlocksAtPos(t *testing.T) {
 			hcl.Pos{Byte: 16},
 			[]string{"foo", "bar"},
 		},
+		"no braces with label newline": {
+			// customblock "fi"\n
+			// Position inside the label "fi" should be inside the block range.
+			"customblock \"fi\"\n",
+			hcl.Pos{Byte: 13}, // inside "fi"
+			[]string{"customblock"},
+		},
+		"no braces two labels newline": {
+			// resource "aws_instance" "foo"\n
+			// Position inside the second label should be inside the block range.
+			"resource \"aws_instance\" \"foo\"\n",
+			hcl.Pos{Byte: 25}, // inside "foo"
+			[]string{"resource"},
+		},
+		"no braces two labels eof": {
+			// resource "aws_instance" "foo" (no newline, EOF)
+			// Position inside the second label should be inside the block range.
+			"resource \"aws_instance\" \"foo\"",
+			hcl.Pos{Byte: 25}, // inside "foo"
+			[]string{"resource"},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

When the HCL parser error-recovers from an incomplete block (no opening brace), `Block.Range()` only covered the type keyword, not the labels. This is because `CloseBraceRange` was set to `ident.Range` as a placeholder, so `RangeBetween(TypeRange, CloseBraceRange)` produced a range that ended at the type keyword.

This caused position-based lookups like `OutermostBlockAtPos` to miss positions within labels, which downstream affected things like `completionAtPos` in hcl-lang skipping incomplete blocks entirely and returning snippets instead of real label candidates.

This attempts to fix this by editing the `finishParsingBodyBlock`'s error-recovery path, setting `CloseBraceRange` to the last label range (falling back to `ident.Range` if no labels exist). This ensures that the range includes more information than before.

## Related Issue
- hashicorp/hcl#365
- hashicorp/hcl#708 (Partially)

## How Has This Been Tested?

I've run the entire test suite and included new tests to cover the new functionality.
