### PR TITLE
fix(json): correct 'occured' -> 'occurred' in ParseFile diagnostics

### DIFF
--- a/json/public.go
+++ b/json/public.go
@@ -108,7 +108,7 @@ func ParseFile(filename string) (rf *hcl.File, diags hcl.Diagnostics) {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
 				Summary:  "Failed to close file",
-				Detail:   fmt.Sprintf("The file %q was opened, but an error occured while closing it.", filename),
+				Detail:   fmt.Sprintf("The file %q was opened, but an error occurred while closing it.", filename),
 			})
 		}
 	}()
@@ -119,7 +119,7 @@ func ParseFile(filename string) (rf *hcl.File, diags hcl.Diagnostics) {
 			{
 				Severity: hcl.DiagError,
 				Summary:  "Failed to read file",
-				Detail:   fmt.Sprintf("The file %q was opened, but an error occured while reading it.", filename),
+				Detail:   fmt.Sprintf("The file %q was opened, but an error occurred while reading it.", filename),
 			},
 		}
 	}


### PR DESCRIPTION
`json/public.go` raised two diagnostics with the wrong spelling:

```go
Detail: fmt.Sprintf("The file %q was opened, but an error occured while closing it.", filename)  // line 111
Detail: fmt.Sprintf("The file %q was opened, but an error occured while reading it.", filename)  // line 122
```

Both messages are surfaced in HCL diagnostic output to end users when `ParseFile` hits a filesystem error. Replace `occured` with `occurred`. `go build ./...` and `go test ./json/` both pass against current `main`.