### PR TITLE
chore: fix user-facing and comment typos (reciever, seperator, occured)

### DIFF
--- a/diagnostic.go
+++ b/diagnostic.go
@@ -173,10 +173,10 @@ type DiagnosticWriter interface {
 //
 // Diagnostic recipients which want to examine "Extra" values to sniff for
 // particular types of extra data can either type-assert this interface
-// directly and repeatedly unwrap until they recieve nil, or can use the
+// directly and repeatedly unwrap until they receive nil, or can use the
 // helper function DiagnosticExtra.
 type DiagnosticExtraUnwrapper interface {
-	// If the reciever is wrapping another "diagnostic extra" value, returns
+	// If the receiver is wrapping another "diagnostic extra" value, returns
 	// that value. Otherwise returns nil to indicate dynamically that nothing
 	// is wrapped.
 	//

--- a/hclwrite/node.go
+++ b/hclwrite/node.go
@@ -59,7 +59,7 @@ func (n *node) Detach() {
 // currently in a list, this function will panic.
 //
 // The return value is the newly-constructed node, containing the given content.
-// After this function returns, the reciever is no longer attached to a list.
+// After this function returns, the receiver is no longer attached to a list.
 func (n *node) ReplaceWith(c nodeContent) *node {
 	if n.list == nil {
 		panic("can't replace node that is not in a list")

--- a/json/parser.go
+++ b/json/parser.go
@@ -235,7 +235,7 @@ Token:
 			recover(p.Read())
 			return nil, diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Missing attribute seperator comma",
+				Summary:  "Missing attribute separator comma",
 				Detail:   "A comma must appear between each property definition in an object.",
 				Subject:  p.Peek().Range.Ptr(),
 			})
@@ -338,7 +338,7 @@ Token:
 			recover(p.Read())
 			return nil, diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Missing attribute seperator comma",
+				Summary:  "Missing attribute separator comma",
 				Detail:   "A comma must appear between each value in an array.",
 				Subject:  p.Peek().Range.Ptr(),
 			})

--- a/json/public.go
+++ b/json/public.go
@@ -108,7 +108,7 @@ func ParseFile(filename string) (rf *hcl.File, diags hcl.Diagnostics) {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
 				Summary:  "Failed to close file",
-				Detail:   fmt.Sprintf("The file %q was opened, but an error occured while closing it.", filename),
+				Detail:   fmt.Sprintf("The file %q was opened, but an error occurred while closing it.", filename),
 			})
 		}
 	}()
@@ -119,7 +119,7 @@ func ParseFile(filename string) (rf *hcl.File, diags hcl.Diagnostics) {
 			{
 				Severity: hcl.DiagError,
 				Summary:  "Failed to read file",
-				Detail:   fmt.Sprintf("The file %q was opened, but an error occured while reading it.", filename),
+				Detail:   fmt.Sprintf("The file %q was opened, but an error occurred while reading it.", filename),
 			},
 		}
 	}

--- a/pos.go
+++ b/pos.go
@@ -249,14 +249,14 @@ func (r Range) Overlap(other Range) Range {
 }
 
 // PartitionAround finds the portion of the given range that overlaps with
-// the reciever and returns three ranges: the portion of the reciever that
+// the receiver and returns three ranges: the portion of the receiver that
 // precedes the overlap, the overlap itself, and then the portion of the
-// reciever that comes after the overlap.
+// receiver that comes after the overlap.
 //
 // If the two ranges do not overlap then all three returned ranges are empty.
 //
 // If the given range aligns with or extends beyond either extent of the
-// reciever then the corresponding outer range will be empty.
+// receiver then the corresponding outer range will be empty.
 func (r Range) PartitionAround(other Range) (before, overlap, after Range) {
 	overlap = r.Overlap(other)
 	if overlap.Empty() {


### PR DESCRIPTION
## Summary

Seven typos across four files; two surface to users via HCL JSON parser diagnostics:

- `json/parser.go` — \`Missing attribute seperator comma\` (two spots) → \`separator\`
- `json/public.go` — \`an error occured while closing/reading it.\` → \`occurred\`

Comment-only fixes:

- `diagnostic.go` — \`recieve\` → \`receive\`, \`reciever\` → \`receiver\`
- `pos.go` — \`reciever\` → \`receiver\` (×3)
- `hclwrite/node.go` — \`reciever\` → \`receiver\`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1 -timeout 120s` — full suite green, including `hclwrite/fuzz`, `integrationtest`, `json`, `json/fuzz`, `specsuite`