### PR TITLE
docs(hclparse): fix outdated package comment API references

### DIFF
--- a/hclparse/parser.go
+++ b/hclparse/parser.go
@@ -4,11 +4,9 @@
 // Package hclparse has the main API entry point for parsing both HCL native
 // syntax and HCL JSON.
 //
-// The main HCL package also includes SimpleParse and SimpleParseFile which
-// can be a simpler interface for the common case where an application just
-// needs to parse a single file. The gohcl package simplifies that further
-// in its SimpleDecode function, which combines hcl.SimpleParse with decoding
-// into Go struct values
+// For simpler use cases, the hclsyntax and json packages provide ParseConfig
+// and ParseFile for loading a single file. The gohcl package provides
+// DecodeBody and DecodeExpression for decoding into Go struct values.
 //
 // Package hclparse, then, is useful for applications that require more fine
 // control over parsing or which need to load many separate files and keep


### PR DESCRIPTION
Replace references to removed SimpleParse/SimpleDecode helpers with current hclsyntax/json and gohcl entry points.

Fixes #793