### PR TITLE
docs(guide): fix broken Go example and nonexistent `gohcl.DecodeBlock` ref in hcldec guide

### DIFF
--- a/guide/go_decoding_hcldec.rst
+++ b/guide/go_decoding_hcldec.rst
@@ -191,7 +191,7 @@ to learn which plugins are needed, but process the block bodies dynamically:
    }
 
    for _, sc := range c.Services {
-       pluginName := block.Type
+       pluginName := sc.Type
 
        // Totally-hypothetical plugin manager (not part of HCL)
        plugin, err := pluginMgr.GetPlugin(pluginName)
@@ -220,7 +220,7 @@ Variables and Functions
 -----------------------
 
 The final argument to ``hcldec.Decode`` is an expression evaluation context,
-just as with ``gohcl.DecodeBlock``.
+just as with ``gohcl.DecodeBody``.
 
 This object can be constructed using
 :ref:`the gohcl helper function <go-decoding-gohcl-evalcontext>` as before if desired, but


### PR DESCRIPTION
Fixes #800.

Two small doc bugs in `guide/go_decoding_hcldec.rst`:

1. The Partial Decoding Go example referenced an undefined variable `block` inside a loop whose loop variable is `sc`, so the example wouldn't compile. Changed to `sc.Type`.
2. The prose referenced `gohcl.DecodeBlock`, which does not exist in the `gohcl` package (only `DecodeBody` and `DecodeExpression` are public). Changed to `gohcl.DecodeBody`.

```diff
 for _, sc := range c.Services {
-    pluginName := block.Type
+    pluginName := sc.Type
```

```diff
-just as with ``gohcl.DecodeBlock``.
+just as with ``gohcl.DecodeBody``.
```