### PR TITLE
hclsyntax: fix body SrcRange start when file begins with a comment

### DIFF
--- a/hclsyntax/parser_test.go
+++ b/hclsyntax/parser_test.go
@@ -2753,6 +2753,49 @@ block "valid" {}
 				},
 			},
 		},
+
+		// Regression: a file starting with a multiline comment had its body
+		// SrcRange start set to the position after the comment rather than
+		// the beginning of the file.
+		{
+			"/* comment */\na = 1\n",
+			0,
+			&Body{
+				Attributes: Attributes{
+					"a": {
+						Name: "a",
+						Expr: &LiteralValueExpr{
+							Val: cty.NumberIntVal(1),
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 5, Byte: 18},
+								End:   hcl.Pos{Line: 2, Column: 6, Byte: 19},
+							},
+						},
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 2, Column: 1, Byte: 14},
+							End:   hcl.Pos{Line: 2, Column: 6, Byte: 19},
+						},
+						NameRange: hcl.Range{
+							Start: hcl.Pos{Line: 2, Column: 1, Byte: 14},
+							End:   hcl.Pos{Line: 2, Column: 2, Byte: 15},
+						},
+						EqualsRange: hcl.Range{
+							Start: hcl.Pos{Line: 2, Column: 3, Byte: 16},
+							End:   hcl.Pos{Line: 2, Column: 4, Byte: 17},
+						},
+					},
+				},
+				Blocks: Blocks{},
+				SrcRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:   hcl.Pos{Line: 3, Column: 1, Byte: 20},
+				},
+				EndRange: hcl.Range{
+					Start: hcl.Pos{Line: 3, Column: 1, Byte: 20},
+					End:   hcl.Pos{Line: 3, Column: 1, Byte: 20},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/hclsyntax/peeker.go
+++ b/hclsyntax/peeker.go
@@ -64,6 +64,13 @@ func (p *peeker) NextRange() hcl.Range {
 
 func (p *peeker) PrevRange() hcl.Range {
 	if p.NextIndex == 0 {
+		// Nothing has been read yet. Return the range of the very first token
+		// in the stream (which may be a comment) so that callers like
+		// ParseBody get a start position that includes any leading comments,
+		// rather than the first non-comment token returned by NextRange/Peek.
+		if len(p.Tokens) > 0 {
+			return p.Tokens[0].Range
+		}
 		return p.NextRange()
 	}
 


### PR DESCRIPTION
## Summary

- Fixes incorrect top-level `Body.SrcRange` when an HCL file starts with a multiline comment
- `ParseBody` captures its start position via `PrevRange()` before reading tokens; with `NextIndex == 0`, that previously fell back to `NextRange()`/`Peek()`, which skips comment tokens
- Body range now starts at the first token in the stream (including leading comments), so `body.Range().ContainsPos(hcl.InitialPos)` is true for files like the one in #551

## Test plan

- [x] Added regression test in `TestParseConfig` for `/* comment */` followed by an attribute
- [x] Verified reproduction from #551 gist: range is now `main.tf:1,1-8,1` instead of `main.tf:3,34-8,1`
- [x] `go test ./hclsyntax/`

Fixes #551