### PR TITLE
Proposal: Generalize the idea of using `[*]` in traversals to describe "traversal patterns"

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclsyntax

--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1773,6 +1773,13 @@ type SplatExpr struct {
 	Source Expression
 	Each   Expression
 	Item   *AnonSymbolExpr
+	// AttrOnly is set when this expression is an "attribute-only" splat
+	// expression, using legacy the .* syntax instead of the modern [*]
+	// syntax, which has some different parsing rules that better match
+	// the splat syntax from HCL's predecessor "HIL". The parser sets this
+	// to indicate when it used the modified precedence rules implied by
+	// using that older syntax.
+	AttrOnly bool
 
 	SrcRange    hcl.Range
 	MarkerRange hcl.Range

--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1968,6 +1968,88 @@ func (e *SplatExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	}
 }
 
+// AsTraversalPattern attempts to interpret the splat expression as a traversal
+// pattern for [hcl.AbsTraversalPatternForExpr].
+//
+// Only splat expressions whose Source also supports
+// [hcl.AbsTraversalPatternForExpr] can be interpreted as traversal patterns,
+// and then only if the "Item" expression can be treated as a series of
+// [SplatExpr] and [RelativeTraversalExpr] nodes.
+//
+// Only the modern [*] variant of splat expression is eligible for use in a
+// traversal pattern. The legacy "attribute-only" splat syntax .* is not
+// permitted in expressions that are to be interpreted as traversal patterns.
+func (e *SplatExpr) AsTraversalPattern() hcl.Traversal {
+	if e.AttrOnly {
+		return nil // attribute-only splats are never eligible
+	}
+	// If the "Source" cannot be interpreted as a traversal pattern then
+	// this is not eligible to be interpreted as a traversal pattern. Success
+	// here gives us a prefix of the traversal pattern we'll return.
+	prefix, diags := hcl.AbsTraversalPatternForExpr(e.Source)
+	if diags.HasErrors() {
+		return nil // not eligible
+	}
+	// We'll start with whatever prefix we just found, and then append from
+	// here as long as our item continues to produce valid traversal pattern
+	// fragments. We'll do early return with nil if we encounter anything that
+	// isn't eligible to be interpreted in this way.
+	// The parser uses the AnonSymbolExpr in e.Item to mark exactly where in
+	// e.Each the iterated items are supposed to be placed, and so we use
+	// comparisons with that here to confirm that any subsequent traversals
+	// or splat expressions are chained in the way we're expecting.
+	var ret hcl.Traversal
+	ret = append(ret, prefix...)
+	currentSplat := e
+	for {
+		if currentSplat.AttrOnly {
+			return nil // attribute-only splats are never eligible
+		}
+		// This TraverseSplat step represents the wildcard step implied by this
+		// splat expression.
+		ret = append(ret, hcl.TraverseSplat{
+			SrcRange: e.MarkerRange,
+		})
+		if currentSplat.Each == currentSplat.Item {
+			// A splat expression whose each is just its item directly means
+			// that there's no subsequent traversal steps, and so we're
+			// done with this and ready to return.
+			break
+		}
+		if rel, ok := currentSplat.Each.(*RelativeTraversalExpr); ok && rel.Source == currentSplat.Item {
+			// This is a relative traversal from each item matched by this splat,
+			// so we can assume this relative traversal represents the remainder
+			// of this traversal pattern.
+			ret = append(ret, rel.Traversal...)
+			break
+		}
+		if next, ok := currentSplat.Each.(*SplatExpr); ok {
+			// Splat expressions nested inside each other are eligible as long
+			// as the source of the next splat is the item of the previous one,
+			// and any intermediate expression is a relative traversal
+			// expression.
+			if rel, ok := next.Source.(*RelativeTraversalExpr); ok && rel.Source == currentSplat.Item {
+				// The steps from the relative traversal appear between this
+				// and the following splat.
+				ret = append(ret, rel.Traversal...)
+			} else if next.Source == currentSplat.Item {
+				// Suggests that the input was [*][*] and so there's no
+				// intermediate traversal to include but we should continue
+				// anyway.
+			} else {
+				return nil // anything else isn't eligible
+			}
+			// ...and then we'll continue with the next level of nesting.
+			currentSplat = next
+			continue
+		}
+		// If we get here then this isn't a shape of AST that is eligible
+		// to be interpreted as a traversal pattern, so we'll bail out now.
+		return nil
+	}
+	return ret
+}
+
 func (e *SplatExpr) walkChildNodes(w internalWalkFunc) {
 	w(e.Source)
 	w(e.Each)

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclsyntax

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -2919,6 +2919,156 @@ func TestExpressionAsTraversal(t *testing.T) {
 	}
 }
 
+func TestExpressionAsTraversalPattern(t *testing.T) {
+	cmpOpts := cmp.Options{
+		// Any cty values that appear in the results should be compared in
+		// the standard way.
+		ctydebug.CmpOptions,
+		// We don't care about specific source ranges in this test. We're
+		// focused only on the overall AST shape.
+		cmp.Comparer(func(_, _ hcl.Range) bool {
+			return true
+		}),
+		// The traverser types all contain an unexported sigil field that
+		// isn't significant to this test.
+		cmpopts.IgnoreUnexported(
+			hcl.TraverseRoot{},
+			hcl.TraverseAttr{},
+			hcl.TraverseIndex{},
+			hcl.TraverseSplat{},
+		),
+	}
+
+	tests := []struct {
+		src  string
+		want hcl.Traversal // nil for cases that should fail
+	}{
+		{
+			`foo`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+			},
+		},
+		{
+			`foo.bar`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseAttr{Name: "bar"},
+			},
+		},
+		{
+			`foo[0]`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseIndex{Key: cty.Zero},
+			},
+		},
+		{
+			`foo["bar"]`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseIndex{Key: cty.StringVal("bar")},
+			},
+		},
+		{
+			`foo[true]`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseIndex{Key: cty.True},
+			},
+		},
+		{
+			`foo[0].bar`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseIndex{Key: cty.Zero},
+				hcl.TraverseAttr{Name: "bar"},
+			},
+		},
+		{
+			`foo[*]`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseSplat{},
+			},
+		},
+		{
+			`foo[*].bar`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseSplat{},
+				hcl.TraverseAttr{Name: "bar"},
+			},
+		},
+		{
+			`foo[*][0]`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseSplat{},
+				hcl.TraverseIndex{Key: cty.Zero},
+			},
+		},
+		{
+			`foo[*].bar[*]`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseSplat{},
+				hcl.TraverseAttr{Name: "bar"},
+				hcl.TraverseSplat{},
+			},
+		},
+		{
+			`foo[*].bar[*].baz`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseSplat{},
+				hcl.TraverseAttr{Name: "bar"},
+				hcl.TraverseSplat{},
+				hcl.TraverseAttr{Name: "baz"},
+			},
+		},
+		{
+			`foo[*][*].bar`,
+			hcl.Traversal{
+				hcl.TraverseRoot{Name: "foo"},
+				hcl.TraverseSplat{},
+				hcl.TraverseSplat{},
+				hcl.TraverseAttr{Name: "bar"},
+			},
+		},
+		{
+			`foo.*`,
+			nil, // attribute-only splat is ineligible
+		},
+		{
+			`foo[*].bar.*.baz`,
+			nil, // attribute-only splat is ineligible
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.src, func(t *testing.T) {
+			expr, diags := ParseExpression([]byte(test.src), "", hcl.InitialPos)
+			if diags.HasErrors() {
+				// All of the input strings in this set of tests are expected
+				// to be valid syntax.
+				t.Fatalf("unexpected errors: %s", diags.Error())
+			}
+
+			got, diags := hcl.AbsTraversalPatternForExpr(expr)
+			if diags.HasErrors() {
+				// AbsTraversalPatternForExpr always returns the same hard-coded
+				// error, so we're only interested in whether it failed or not.
+				got = nil
+			}
+
+			if diff := cmp.Diff(test.want, got, cmpOpts); diff != "" {
+				t.Error("wrong result\n" + diff)
+			}
+		})
+	}
+}
+
 func TestStaticExpressionList(t *testing.T) {
 	expr, _ := ParseExpression([]byte("[0, a, true]"), "", hcl.Pos{})
 	exprs, diags := hcl.ExprList(expr)

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
@@ -2932,6 +2934,271 @@ func TestStaticExpressionList(t *testing.T) {
 	}
 	if !first.Val.RawEquals(cty.Zero) {
 		t.Fatalf("wrong first value %#v; want cty.Zero", first.Val)
+	}
+}
+
+func TestParseExpression_traversalsAndSplats(t *testing.T) {
+	// The implementations of the "AsTraversal" method used by
+	// [hcl.AbsTraversalForExpr] rely on absolute traversal, relative traversal,
+	// and splat expressions producing particular shapes of parse tree, and so
+	// the test cases here are intended to ensure we don't inadvertently change
+	// these parse tree shapes under future maintenence.
+
+	cmpOpts := cmp.Options{
+		// Any cty values that appear in the results should be compared in
+		// the standard way.
+		ctydebug.CmpOptions,
+		// We don't care about specific source ranges in this test. We're
+		// focused only on the overall AST shape.
+		cmp.Comparer(func(_, _ hcl.Range) bool {
+			return true
+		}),
+		cmpopts.IgnoreUnexported(
+			// The traverser types all contain an unexported sigil field that
+			// isn't significant to this test.
+			hcl.TraverseRoot{},
+			hcl.TraverseAttr{},
+			hcl.TraverseIndex{},
+			// We also ignore the temporary state fields of AnonSymbolExpr,
+			// and worry only about where this type appears in the AST.
+			AnonSymbolExpr{},
+		),
+	}
+
+	tests := []struct {
+		src  string
+		want hcl.Expression
+	}{
+		{
+			`foo`,
+			&ScopeTraversalExpr{
+				Traversal: hcl.Traversal{
+					hcl.TraverseRoot{
+						Name: "foo",
+					},
+				},
+			},
+		},
+		{
+			`foo.bar`,
+			&ScopeTraversalExpr{
+				Traversal: hcl.Traversal{
+					hcl.TraverseRoot{
+						Name: "foo",
+					},
+					hcl.TraverseAttr{
+						Name: "bar",
+					},
+				},
+			},
+		},
+		{
+			`foo[0]`,
+			&ScopeTraversalExpr{
+				Traversal: hcl.Traversal{
+					hcl.TraverseRoot{
+						Name: "foo",
+					},
+					hcl.TraverseIndex{
+						Key: cty.Zero,
+					},
+				},
+			},
+		},
+		{
+			`foo["bar"]`,
+			&ScopeTraversalExpr{
+				Traversal: hcl.Traversal{
+					hcl.TraverseRoot{
+						Name: "foo",
+					},
+					hcl.TraverseIndex{
+						Key: cty.StringVal("bar"),
+					},
+				},
+			},
+		},
+		{
+			`foo[true]`,
+			&ScopeTraversalExpr{
+				Traversal: hcl.Traversal{
+					hcl.TraverseRoot{
+						Name: "foo",
+					},
+					hcl.TraverseIndex{
+						Key: cty.True,
+					},
+				},
+			},
+		},
+		{
+			`foo[0].bar`,
+			&ScopeTraversalExpr{
+				Traversal: hcl.Traversal{
+					hcl.TraverseRoot{
+						Name: "foo",
+					},
+					hcl.TraverseIndex{
+						Key: cty.Zero,
+					},
+					hcl.TraverseAttr{
+						Name: "bar",
+					},
+				},
+			},
+		},
+		{
+			`foo[*]`,
+			&SplatExpr{
+				Source: &ScopeTraversalExpr{
+					Traversal: hcl.Traversal{
+						hcl.TraverseRoot{
+							Name: "foo",
+						},
+					},
+				},
+				Each: &AnonSymbolExpr{},
+				Item: &AnonSymbolExpr{},
+			},
+		},
+		{
+			`foo[*].bar`,
+			&SplatExpr{
+				Source: &ScopeTraversalExpr{
+					Traversal: hcl.Traversal{
+						hcl.TraverseRoot{
+							Name: "foo",
+						},
+					},
+				},
+				Each: &RelativeTraversalExpr{
+					Source: &AnonSymbolExpr{},
+					Traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "bar",
+						},
+					},
+				},
+				Item: &AnonSymbolExpr{},
+			},
+		},
+		{
+			`foo[*][0]`,
+			&SplatExpr{
+				Source: &ScopeTraversalExpr{
+					Traversal: hcl.Traversal{
+						hcl.TraverseRoot{
+							Name: "foo",
+						},
+					},
+				},
+				Each: &RelativeTraversalExpr{
+					Source: &AnonSymbolExpr{},
+					Traversal: hcl.Traversal{
+						hcl.TraverseIndex{
+							Key: cty.Zero,
+						},
+					},
+				},
+				Item: &AnonSymbolExpr{},
+			},
+		},
+		{
+			`foo[*].bar[*]`,
+			&SplatExpr{
+				Source: &ScopeTraversalExpr{
+					Traversal: hcl.Traversal{
+						hcl.TraverseRoot{
+							Name: "foo",
+						},
+					},
+				},
+				Each: &SplatExpr{
+					Source: &RelativeTraversalExpr{
+						Source: &AnonSymbolExpr{},
+						Traversal: hcl.Traversal{
+							hcl.TraverseAttr{
+								Name: "bar",
+							},
+						},
+					},
+					Each: &AnonSymbolExpr{},
+					Item: &AnonSymbolExpr{},
+				},
+				Item: &AnonSymbolExpr{},
+			},
+		},
+		{
+			`foo[*].bar[*].baz`,
+			&SplatExpr{
+				Source: &ScopeTraversalExpr{
+					Traversal: hcl.Traversal{
+						hcl.TraverseRoot{
+							Name: "foo",
+						},
+					},
+				},
+				Each: &SplatExpr{
+					Source: &RelativeTraversalExpr{
+						Source: &AnonSymbolExpr{},
+						Traversal: hcl.Traversal{
+							hcl.TraverseAttr{
+								Name: "bar",
+							},
+						},
+					},
+					Each: &RelativeTraversalExpr{
+						Source: &AnonSymbolExpr{},
+						Traversal: hcl.Traversal{
+							hcl.TraverseAttr{
+								Name: "baz",
+							},
+						},
+					},
+					Item: &AnonSymbolExpr{},
+				},
+				Item: &AnonSymbolExpr{},
+			},
+		},
+		{
+			`foo[*][*].bar`,
+			&SplatExpr{
+				Source: &ScopeTraversalExpr{
+					Traversal: hcl.Traversal{
+						hcl.TraverseRoot{
+							Name: "foo",
+						},
+					},
+				},
+				Each: &SplatExpr{
+					Source: &AnonSymbolExpr{},
+					Each: &RelativeTraversalExpr{
+						Source: &AnonSymbolExpr{},
+						Traversal: hcl.Traversal{
+							hcl.TraverseAttr{
+								Name: "bar",
+							},
+						},
+					},
+					Item: &AnonSymbolExpr{},
+				},
+				Item: &AnonSymbolExpr{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.src, func(t *testing.T) {
+			got, diags := ParseExpression([]byte(test.src), "", hcl.InitialPos)
+			if diags.HasErrors() {
+				// All of the input strings in this set of tests are expected
+				// to be valid syntax.
+				t.Fatalf("unexpected errors: %s", diags.Error())
+			}
+
+			if diff := cmp.Diff(test.want, got, cmpOpts); diff != "" {
+				t.Error("wrong result\n" + diff)
+			}
+		})
 	}
 }
 

--- a/hclsyntax/parser.go
+++ b/hclsyntax/parser.go
@@ -801,9 +801,10 @@ Traversal:
 				}
 
 				ret = &SplatExpr{
-					Source: ret,
-					Each:   travExpr,
-					Item:   itemExpr,
+					Source:   ret,
+					Each:     travExpr,
+					Item:     itemExpr,
+					AttrOnly: true,
 
 					SrcRange:    hcl.RangeBetween(from.Range(), lastRange),
 					MarkerRange: hcl.RangeBetween(dot.Range, marker.Range),

--- a/hclsyntax/parser_traversal.go
+++ b/hclsyntax/parser_traversal.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclsyntax

--- a/hclsyntax/parser_traversal.go
+++ b/hclsyntax/parser_traversal.go
@@ -17,19 +17,20 @@ func (p *parser) ParseTraversalAbs() (hcl.Traversal, hcl.Diagnostics) {
 	return p.parseTraversal(false)
 }
 
-// ParseTraversalPartial parses an absolute traversal that is permitted
+// ParseTraversalAbsPattern parses an absolute traversal that is permitted
 // to contain splat ([*]) expressions. Only splat expressions within square
 // brackets are permitted ([*]); splat expressions within attribute names are
 // not permitted (.*).
 //
-// The meaning of partial here is that the traversal may be incomplete, in that
-// any splat expression indicates reference to a potentially unknown number of
-// elements.
+// The term "traversal pattern" means a traversal that contains at least one
+// wildcard element represented as [hcl.TraverseSplat], which represents an
+// arbitrary number of matching elements.
 //
-// Traversals that include splats cannot be automatically traversed by HCL using
+// Traversal patterns cannot be automatically traversed by HCL using
 // the TraversalAbs or TraversalRel methods. Instead, the caller must handle
-// the traversals manually.
-func (p *parser) ParseTraversalPartial() (hcl.Traversal, hcl.Diagnostics) {
+// the traversals manually, typically for static analysis rather than actual
+// evaluation.
+func (p *parser) ParseTraversalAbsPattern() (hcl.Traversal, hcl.Diagnostics) {
 	return p.parseTraversal(true)
 }
 

--- a/hclsyntax/public.go
+++ b/hclsyntax/public.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclsyntax

--- a/hclsyntax/public.go
+++ b/hclsyntax/public.go
@@ -118,16 +118,19 @@ func ParseTraversalAbs(src []byte, filename string, start hcl.Pos) (hcl.Traversa
 	return expr, diags
 }
 
-// ParseTraversalPartial matches the behavior of ParseTraversalAbs except
-// that it allows splat expressions ([*]) to appear in the traversal.
+// ParseTraversalAbsPattern matches the behavior of ParseTraversalAbs except
+// that it allows splat expressions ([*]) to appear in the traversal, and
+// so it can potentially return traversal patterns rather than just concrete
+// traversals.
 //
-// The returned traversals are "partial" in that the splat expression indicates
-// an unknown value for the index.
+// The returned traversals are "partial" in that the splat steps represent
+// a wildcard value for indexing.
 //
-// Traversals that include splats cannot be automatically traversed by HCL using
-// the TraversalAbs or TraversalRel methods. Instead, the caller must handle
-// the traversals manually.
-func ParseTraversalPartial(src []byte, filename string, start hcl.Pos) (hcl.Traversal, hcl.Diagnostics) {
+// Traversal patterns cannot be automatically traversed using the TraversalAbs
+// or TraversalRel methods. Instead, the caller must handle the traversals
+// manually. Use [hcl.Traversal.IsPattern] to distinguish traversal patterns
+// from concrete traversals.
+func ParseTraversalAbsPattern(src []byte, filename string, start hcl.Pos) (hcl.Traversal, hcl.Diagnostics) {
 	tokens, diags := LexExpression(src, filename, start)
 	peeker := newPeeker(tokens, false)
 	parser := &parser{peeker: peeker}
@@ -136,7 +139,7 @@ func ParseTraversalPartial(src []byte, filename string, start hcl.Pos) (hcl.Trav
 	// they were wrapped in parentheses.
 	parser.PushIncludeNewlines(false)
 
-	expr, parseDiags := parser.ParseTraversalPartial()
+	expr, parseDiags := parser.ParseTraversalAbsPattern()
 	diags = append(diags, parseDiags...)
 
 	parser.PopIncludeNewlines()
@@ -147,6 +150,15 @@ func ParseTraversalPartial(src []byte, filename string, start hcl.Pos) (hcl.Trav
 	peeker.AssertEmptyIncludeNewlinesStack()
 
 	return expr, diags
+}
+
+// ParseTraversalPartial is a legacy alias for [ParseTraversalAbsPattern], from
+// before the "traversal pattern" terminology was adopted.
+//
+// Deprecated: This is here only for backward-compatibility. Use
+// [ParseTraversalAbsPattern] instead in new code.
+func ParseTraversalPartial(src []byte, filename string, start hcl.Pos) (hcl.Traversal, hcl.Diagnostics) {
+	return ParseTraversalAbsPattern(src, filename, start)
 }
 
 // LexConfig performs lexical analysis on the given buffer, treating it as a

--- a/hclsyntax/structure.go
+++ b/hclsyntax/structure.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclsyntax

--- a/hclsyntax/structure_test.go
+++ b/hclsyntax/structure_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclsyntax

--- a/json/structure.go
+++ b/json/structure.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package json

--- a/json/structure.go
+++ b/json/structure.go
@@ -582,6 +582,23 @@ func (e *expression) AsTraversal() hcl.Traversal {
 	}
 }
 
+// Implementation for hcl.AbsTraversalPatternForExpr.
+func (e *expression) AsTraversalPattern() hcl.Traversal {
+	// In JSON-based syntax a traversal pattern is given as a string containing
+	// traversal syntax as defined by hclsyntax.ParseTraversalAbsPattern.
+
+	switch v := e.src.(type) {
+	case *stringVal:
+		traversal, diags := hclsyntax.ParseTraversalAbsPattern([]byte(v.Value), v.SrcRange.Filename, v.SrcRange.Start)
+		if diags.HasErrors() {
+			return nil
+		}
+		return traversal
+	default:
+		return nil
+	}
+}
+
 // Implementation for hcl.ExprCall.
 func (e *expression) ExprCall() *hcl.StaticCall {
 	// In JSON-based syntax a static call is given as a string containing

--- a/json/structure_test.go
+++ b/json/structure_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package json

--- a/json/structure_test.go
+++ b/json/structure_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -1335,6 +1336,62 @@ func TestExpressionAsTraversal(t *testing.T) {
 	traversal := e.AsTraversal()
 	if len(traversal) != 3 {
 		t.Fatalf("incorrect traversal %#v; want length 3", traversal)
+	}
+}
+
+func TestExpressionAsTraversalPattern(t *testing.T) {
+	e := &expression{
+		src: &stringVal{
+			Value: "foo.bar[*]",
+			SrcRange: hcl.Range{
+				Filename: "test.hcl.json",
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 1,
+					Byte:   0,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 11,
+					Byte:   10,
+				},
+			},
+		},
+	}
+	// AbsTraversalPatternForExpr relies on [expression.AsTraversalPattern],
+	// so that's actually the main thing we're testing here.
+	got, diags := hcl.AbsTraversalPatternForExpr(e)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+	want := hcl.Traversal{
+		hcl.TraverseRoot{
+			Name: "foo",
+			SrcRange: hcl.Range{
+				Filename: "test.hcl.json",
+				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+				End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+			},
+		},
+		hcl.TraverseAttr{
+			Name: "bar",
+			SrcRange: hcl.Range{
+				Filename: "test.hcl.json",
+				Start:    hcl.Pos{Line: 1, Column: 4, Byte: 3},
+				End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			},
+		},
+		hcl.TraverseSplat{
+			SrcRange: hcl.Range{
+				Filename: "test.hcl.json",
+				Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+				End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			},
+		},
+	}
+	cmpOpts := cmp.AllowUnexported(hcl.TraverseRoot{}, hcl.TraverseAttr{}, hcl.TraverseSplat{})
+	if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
+		t.Error("wrong result\n" + diff)
 	}
 }
 

--- a/traversal.go
+++ b/traversal.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hcl

--- a/traversal.go
+++ b/traversal.go
@@ -20,6 +20,13 @@ import (
 //
 // A traversal can be absolute (its first value is a symbol name) or relative
 // (starts from an existing value).
+//
+// This type is also sometimes used to represent "traversal patterns", which
+// contain wildcard steps represented as [TraverseSplat] values. Traversal
+// patterns cannot be evaluated but can be used for static analysis. Traversal
+// patterns are produced only by specialized functions that are documented as
+// doing so, so callers of functions not so documented can assume that the
+// result is never a traversal pattern.
 type Traversal []Traverser
 
 // TraversalJoin appends a relative traversal to an absolute traversal to
@@ -132,6 +139,24 @@ func (t Traversal) IsRelative() bool {
 	return true
 }
 
+// IsPattern returns true if the reciever is a traversal pattern rather than
+// a concrete traversal.
+//
+// In other words, this returns true if there are any [TraverseSplat] items in
+// the traversal, representing a placeholder for an arbitrary index that isn't
+// yet chosen.
+//
+// A traversal pattern is only useful for static analysis, and cannot be
+// evaluated to produce a value.
+func (t Traversal) IsPattern() bool {
+	for _, step := range t {
+		if _, ok := step.(TraverseSplat); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // SimpleSplit returns a TraversalSplit where the name lookup is the absolute
 // part and the remainder is the relative part. Supported only for
 // absolute traversals, and will panic if applied to a relative traversal.
@@ -240,7 +265,7 @@ type TraverseRoot struct {
 	SrcRange Range
 }
 
-// TraversalStep on a TraverseName immediately panics, because absolute
+// TraversalStep on a TraverseRoot immediately panics, because absolute
 // traversals cannot be directly traversed.
 func (tn TraverseRoot) TraversalStep(cty.Value) (cty.Value, Diagnostics) {
 	panic("Cannot traverse an absolute traversal")
@@ -280,15 +305,39 @@ func (tn TraverseIndex) SourceRange() Range {
 	return tn.SrcRange
 }
 
-// TraverseSplat applies the splat operation to its initial value.
+// TraverseSplat acts as a placeholder for an arbitrary index in a traversal
+// pattern.
+//
+// Any [hcl.Traversal] containing at least one step of this type represents a
+// traversal pattern rather than a concrete traversal, and so it cannot be
+// evaluated but it can be used for static analysis.
+//
+// This type has a somewhat-confusing name because it originated as a leftover
+// mistake from an unreleased earlier version of HCL, which was retroactively
+// adopted to represent a "wildcard" in a traversal pattern just because in
+// the HCL native syntax the wildcard syntax is based on the splat expression
+// syntax.
 type TraverseSplat struct {
 	isTraverser
+	// Each is a historical mistake that is no longer used. The subsequent
+	// items in a traversal pattern are instead just flattened into the
+	// containing hcl.Traversal as additional elements.
 	Each     Traversal
 	SrcRange Range
 }
 
+// TraversalStep on a TraverseSplat always returns an error, because the
+// presence of a step of this type means that the container is a traversal
+// pattern rather than a concrete traversal.
 func (tn TraverseSplat) TraversalStep(val cty.Value) (cty.Value, Diagnostics) {
-	panic("TraverseSplat not yet implemented")
+	var diags Diagnostics
+	diags = diags.Append(&Diagnostic{
+		Severity: DiagError,
+		Summary:  "Cannot evaluate traversal pattern",
+		Detail:   "This is a pattern for matching against traversals rather than a concrete traversal, so it cannot be directly evaluated.",
+		Subject:  &tn.SrcRange,
+	})
+	return cty.DynamicVal, diags
 }
 
 func (tn TraverseSplat) SourceRange() Range {

--- a/traversal_for_expr.go
+++ b/traversal_for_expr.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hcl

--- a/traversal_for_expr.go
+++ b/traversal_for_expr.go
@@ -45,6 +45,60 @@ func AbsTraversalForExpr(expr Expression) (Traversal, Diagnostics) {
 	}
 }
 
+// AbsTraversalPatternForExpr is an extension of [AbsTraversalForExpr] that
+// additionally allows "traversal patterns", which are allowed to contain
+// wildcard steps represented as [TraverseSplat] values.
+//
+// Unlike concrete traversals, traversal patterns cannot be evaluated to produce
+// a single value as a result. Instead, they are primarily intended for static
+// analysis, such as when using splat-expression-like syntax to describe a
+// set of zero or more traversals that are included in some collection.
+//
+// A particular Expression implementation can support this function by
+// offering a method called AsTraversalPattern that takes no arguments and
+// returns either a valid absolute traversal pattern or nil to indicate that
+// no traversal pattern is possible. Alternatively, an implementation can
+// support UnwrapExpression to delegate handling of this function to a wrapped
+// Expression object.
+//
+// The concept of traversal patterns was added quite some time after the
+// concept of concrete traversals, and so not all expressions which support
+// [AbsTraversalForExpr] necessarily support traversal patterns. If the given
+// expression object does not have a suitable AsTraversalPattern method then
+// this will attempt to fall back to [AbsTraversalForExpr] to at least support
+// the concrete subset of the traversal syntax.
+func AbsTraversalPatternForExpr(expr Expression) (Traversal, Diagnostics) {
+	type asTraversalPattern interface {
+		AsTraversalPattern() Traversal
+	}
+
+	physExpr := UnwrapExpressionUntil(expr, func(expr Expression) bool {
+		_, supported := expr.(asTraversalPattern)
+		return supported
+	})
+
+	if asT, supported := physExpr.(asTraversalPattern); supported {
+		if traversal := asT.AsTraversalPattern(); traversal != nil {
+			return traversal, nil
+		}
+	}
+	// If we weren't able to use AsTraversalPattern then we'll attempt to
+	// at least support the AsTraversal method to produce a concrete traversal,
+	// but we have a custom error message if it doesn't work.
+	concrete, diags := AbsTraversalForExpr(expr)
+	if diags.HasErrors() {
+		return nil, Diagnostics{
+			&Diagnostic{
+				Severity: DiagError,
+				Summary:  "Invalid expression",
+				Detail:   "A single static variable reference or wildcard pattern is required: only attribute access, indexing with constant keys, or wildcard steps using splat expression syntax. No calculations, function calls, template expressions, etc are allowed here.",
+				Subject:  expr.Range().Ptr(),
+			},
+		}
+	}
+	return concrete, nil
+}
+
 // RelTraversalForExpr is similar to AbsTraversalForExpr but it returns
 // a relative traversal instead. Due to the nature of HCL expressions, the
 // first element of the returned traversal is always a TraverseAttr, and


### PR DESCRIPTION
The earlier PR https://github.com/hashicorp/hcl/pull/673 introduced `hclsyntax.ParseTraversalPartial` that is a variant of `hclsyntax.ParseTraversalAbs` which additionally accepts `[*]` steps representing placeholders for arbitrary indices. It introduced a new use of the previously-vestigial `hcl.TraverseSplat` type[^1] as the representation of those placeholders.

However, that idea wasn't generalized to the other main way callers can produce `hcl.Traversal` values: asking HCL to perform static analysis of an already-parsed expression, like Terraform does when it's analyzing references in parts of its language like `depends_on` and the `from`/`to` expressions in `moved`, `removed`, and `import` blocks.

This PR is proposing to generalize this idea of "traversals with wildcards" into a new first-class concept that I've called "traversal patterns". This new idea extends the idea of "traversal" to include the possibility of `hcl.TraverseSplat` steps, and makes it possible to turn both source code _and_ certain already-parsed expressions into traversal patterns.

Of course I have my own reasons to propose this, but as a "closer-to-home" motivation consider that Terraform could hypothetically use this to support wildcard patterns in `removed` blocks:

```hcl
removed {
  # Forget rather than destroy the database object in _any_ instance of
  # this module call, rather than having to name each one individually.
  from = module.example[*].aws_db_instance.example

  lifecycle {
    destroy = false
  }
}
```

...or for wildcard index steps in `ignore_changes` for list-based blocks, without having to write out every possible index explicitly (https://github.com/hashicorp/terraform/issues/5666):

```hcl
  lifecycle {
    ignore_changes = [
      # Ignore changes to the last_updated attribute in all blocks
      # of type "listy_thing", regardless of how many there are.
      listy_thing[*].last_updated,
    ]
  }
```

I understand that there'd be a lot more work to do in Terraform to do these things than _just_ merging this PR, but this changeset would create a new building block in the HCL grammar for languages like Terraform's to use.

The `ParseTraversalPartial` function was already producing traversals that can't support `Traversal.Value`, and that remains true for the concept of "traversal pattern" introduced here. However, calls to `Value` now return an error diagnostic instead of panicking as before.

Turning an AST that includes a mixture of absolute traversals, relative traversals, and splat expressions into a flat `hcl.Traversal` is kinda annoying to achieve and so the code I wrote for it here is honestly quite dense and tricky to follow, but I tried to write a good suite of unit tests covering it, both at the parser level (to make sure the parser generates the AST that the flattening code expects) and at the "as traversal pattern" level.

[^1]: That `TraverseSplat` type originated from a much earlier implementation of splat expressions in the ZCL library that HCL 2 was forked from, where they were treated as a special kind of traversal step instead of as the separate expression type `hclsyntax.SplatExpr`.

    I forgot to actually remove the `TraverseSplat` type after rewriting the implementation of splat expressions and so it ended up surviving into the first stable release of HCL 2 but without any uses until `hclsyntax.ParseTraversalPartial` came along and gave it a new purpose.
