### PR TITLE
hclwrite: `body.SetAttribute*` return new attribute

### DIFF
--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -159,13 +159,16 @@ func (b *Body) RemoveBlock(block *Block) bool {
 // The same caveats apply to this function as for NewExpressionRaw on which
 // it is based. If possible, prefer to use SetAttributeValue or
 // SetAttributeTraversal.
+//
+// The return value is the attribute that was either modified in-place or
+// created.
 func (b *Body) SetAttributeRaw(name string, tokens Tokens) *Attribute {
 	attr := b.GetAttribute(name)
 	expr := NewExpressionRaw(tokens)
 	if attr != nil {
 		attr.expr = attr.expr.ReplaceWith(expr)
 	} else {
-		attr := newAttribute()
+		attr = newAttribute()
 		attr.init(name, expr)
 		b.appendItem(attr)
 	}
@@ -186,7 +189,7 @@ func (b *Body) SetAttributeValue(name string, val cty.Value) *Attribute {
 	if attr != nil {
 		attr.expr = attr.expr.ReplaceWith(expr)
 	} else {
-		attr := newAttribute()
+		attr = newAttribute()
 		attr.init(name, expr)
 		b.appendItem(attr)
 	}
@@ -207,7 +210,7 @@ func (b *Body) SetAttributeTraversal(name string, traversal hcl.Traversal) *Attr
 	if attr != nil {
 		attr.expr = attr.expr.ReplaceWith(expr)
 	} else {
-		attr := newAttribute()
+		attr = newAttribute()
 		attr.init(name, expr)
 		b.appendItem(attr)
 	}

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -4,6 +4,7 @@
 package hclwrite
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"strings"
@@ -769,6 +770,44 @@ func TestBodySetAttributeTraversal(t *testing.T) {
 	}
 }
 
+func TestBodySetAttributeTraversal_ReturnsTheAttribute(t *testing.T) {
+	tests := map[string]struct {
+		config string
+		want   string
+	}{
+		"attribute `one` is already set to a value": {
+			config: `one = 1`,
+			want:   `one =the.loneliest.number`,
+		},
+		"attribute `one` is not set to a value": {
+			config: `two = 2`,
+			want:   `one=the.loneliest.number` + "\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := must[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
+
+			traversal := hcl.Traversal{
+				hcl.TraverseRoot{Name: "the"},
+				hcl.TraverseAttr{Name: "loneliest"},
+				hcl.TraverseAttr{Name: "number"},
+			}
+
+			attr := f.Body().SetAttributeTraversal(`one`, traversal)
+			if attr == nil {
+				t.Fatalf("got: nil\nwant: %s", test.want)
+			}
+
+			got := attr.BuildTokens(nil).Bytes()
+			if !bytes.Equal(got, []byte(test.want)) {
+				t.Errorf("got: %s\nwant: %s", got, test.want)
+			}
+		})
+	}
+}
+
 func TestBodySetAttributeRaw(t *testing.T) {
 	tests := []struct {
 		src    string
@@ -928,6 +967,69 @@ func TestBodySetAttributeRaw(t *testing.T) {
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
+			}
+		})
+	}
+}
+
+func TestBodySetAttributeRaw_ReturnsTheAttribute(t *testing.T) {
+	tests := map[string]struct {
+		config string
+		want   string
+	}{
+		"attribute `one` is already set to a value": {
+			config: `one = 1`,
+			want:   `one ="the loneliest number"`,
+		},
+		"attribute `one` is not set to a value": {
+			config: `two = 2`,
+			want:   `one="the loneliest number"` + "\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := must[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
+
+			attr := f.Body().SetAttributeRaw(`one`, TokensForValue(cty.StringVal("the loneliest number")))
+			if attr == nil {
+				t.Fatalf("got: nil\nwant: %s", test.want)
+			}
+
+			got := attr.BuildTokens(nil).Bytes()
+			if !bytes.Equal(got, []byte(test.want)) {
+				t.Errorf("got: %s\nwant: %s", got, test.want)
+			}
+		})
+	}
+}
+func TestBodySetAttributeValue_ReturnsTheAttribute(t *testing.T) {
+	tests := map[string]struct {
+		config string
+		want   string
+	}{
+		"attribute `one` is already set to a value": {
+			config: `one = 1`,
+			want:   `one ="the loneliest number"`,
+		},
+		"attribute `one` is not set to a value": {
+			config: `two = 2`,
+			want:   `one="the loneliest number"` + "\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := must[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
+
+			attr := f.Body().SetAttributeValue(`one`, cty.StringVal("the loneliest number"))
+			if attr == nil {
+				t.Fatalf("got: nil\nwant: %s", test.want)
+			}
+
+			got := attr.BuildTokens(nil).Bytes()
+			if !bytes.Equal(got, []byte(test.want)) {
+				t.Errorf("got: %s\nwant: %s", got, test.want)
 			}
 		})
 	}
@@ -1753,4 +1855,24 @@ bar {}
 		t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(want), diff)
 	}
 
+}
+
+// must is a convenience function that wraps a function call that returns a
+// value and diagnostics.
+//
+// If there are no diagnostics, returns the value.
+// If there are diagnostics, fails the test.
+func must[E any](t *testing.T) func(value E, diags hcl.Diagnostics) E {
+	t.Helper()
+
+	return func(value E, diags hcl.Diagnostics) E {
+		if len(diags) != 0 {
+			for _, diag := range diags {
+				t.Logf("- %s", diag.Error())
+			}
+			t.Fatalf("unexpected diagnostics")
+		}
+
+		return value
+	}
 }

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -787,7 +787,7 @@ func TestBodySetAttributeTraversal_ReturnsTheAttribute(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			f := must[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
+			f := testFn[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
 
 			traversal := hcl.Traversal{
 				hcl.TraverseRoot{Name: "the"},
@@ -989,7 +989,7 @@ func TestBodySetAttributeRaw_ReturnsTheAttribute(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			f := must[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
+			f := testFn[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
 
 			attr := f.Body().SetAttributeRaw(`one`, TokensForValue(cty.StringVal("the loneliest number")))
 			if attr == nil {
@@ -1020,7 +1020,7 @@ func TestBodySetAttributeValue_ReturnsTheAttribute(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			f := must[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
+			f := testFn[*File](t)(ParseConfig([]byte(test.config), "", hcl.Pos{Line: 1, Column: 1}))
 
 			attr := f.Body().SetAttributeValue(`one`, cty.StringVal("the loneliest number"))
 			if attr == nil {
@@ -1857,12 +1857,12 @@ bar {}
 
 }
 
-// must is a convenience function that wraps a function call that returns a
+// testFn is a convenience function that wraps a function call that returns a
 // value and diagnostics.
 //
 // If there are no diagnostics, returns the value.
 // If there are diagnostics, fails the test.
-func must[E any](t *testing.T) func(value E, diags hcl.Diagnostics) E {
+func testFn[E any](t *testing.T) func(value E, diags hcl.Diagnostics) E {
 	t.Helper()
 
 	return func(value E, diags hcl.Diagnostics) E {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

This change updates `hclwrite.Body.SetAttribute*` to return the new attribute rather than return `nil`.

This matches the intent in the documentation comments that indicate:

> The return value is the attribute that was either modified in-place or created.

An available workaround:
```go 
body.SetAttributeRaw(name, tokens)
attr := body.GetAttribute(name)
```

Open question: I'm considering whether to check the return value of `Body.SetAttribute*` in `hclwrite/ast_body_test.go`.