### PR TITLE
hclwrite: export `LeadComments()`/`LineComments()`

### DIFF
--- a/hclwrite/ast_attribute.go
+++ b/hclwrite/ast_attribute.go
@@ -46,6 +46,10 @@ func (a *Attribute) init(name string, expr *Expression) {
 	})
 }
 
+func (a *Attribute) LeadComments() Tokens {
+	return a.leadComments.content.BuildTokens(nil)
+}
+
 func (a *Attribute) Expr() *Expression {
 	return a.expr.content.(*Expression)
 }

--- a/hclwrite/ast_attribute.go
+++ b/hclwrite/ast_attribute.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/ast_attribute.go
+++ b/hclwrite/ast_attribute.go
@@ -50,6 +50,10 @@ func (a *Attribute) LeadComments() Tokens {
 	return a.leadComments.content.BuildTokens(nil)
 }
 
+func (a *Attribute) LineComments() Tokens {
+	return a.lineComments.content.BuildTokens(nil)
+}
+
 func (a *Attribute) Expr() *Expression {
 	return a.expr.content.(*Expression)
 }

--- a/hclwrite/ast_attribute_test.go
+++ b/hclwrite/ast_attribute_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package hclwrite
 
 import (
@@ -35,17 +38,14 @@ test_attribute = foo
 			`// comment
 `,
 		},
-		"go formatted multi-line comment": {
-			`
-/* syntactically valid multi-line 
+		"go formatted multi-line comment": {`
+/* 
+	go-style multi-line 
 	comment 
 */
 test_attribute = foo
 `,
-			`/* syntactically valid multi-line 
-comment
-*/
-`,
+			``, //unsupported
 		},
 	}
 
@@ -92,7 +92,7 @@ test_attribute = foo # multi-line
 					 # comment (invalid)
 `,
 			` # multi-line
-`, // not sure where the second line went, but I would guess it's interpreted as the next attrs's lead comment?
+`, // known limitation: any extra comment lines (when using single-comment syntax) are dropped
 		},
 		{
 			`
@@ -102,7 +102,7 @@ test_attribute = foo /* multi-line
 `,
 			` /* multi-line
                         comment in a weird place
-                     */`, //why did this newline get swallowed when others didn't?
+                     */`, // note that all the whitespaces are returned
 		},
 	}
 

--- a/hclwrite/ast_attribute_test.go
+++ b/hclwrite/ast_attribute_test.go
@@ -1,0 +1,125 @@
+package hclwrite
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+func TestAttributeLeadComments(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		"basic comment": {`
+# comment
+test_attribute = foo
+`,
+			`# comment
+`,
+		},
+		"basic multiline comment": {`
+# multi-line
+# comment (singe comment formatting)
+test_attribute = foo
+`,
+			`# multi-line
+# comment (singe comment formatting)
+`,
+		},
+		"go formatted comment": {
+			`
+// comment
+test_attribute = foo
+`,
+			`// comment
+`,
+		},
+		"go formatted multi-line comment": {
+			`
+/* syntactically valid multi-line 
+	comment 
+*/
+test_attribute = foo
+`,
+			`/* syntactically valid multi-line 
+comment
+*/
+`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			f, diags := ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != 0 {
+				for _, diag := range diags {
+					t.Logf("- %s", diag.Error())
+				}
+				t.Fatalf("unexpected diagnostics")
+			}
+			attr := f.Body().Attributes()["test_attribute"]
+			got := string(attr.LeadComments().Bytes())
+			if got != test.want {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAttributeLineComments(t *testing.T) {
+	tests := []struct {
+		src  string
+		want string
+	}{
+		{
+			`
+test_attribute = foo # comment
+`,
+			` # comment
+`,
+		},
+		{
+			`
+test_attribute = foo // comment
+`,
+			` // comment
+`,
+		},
+		{
+			`
+test_attribute = foo # multi-line
+					 # comment (invalid)
+`,
+			` # multi-line
+`, // not sure where the second line went, but I would guess it's interpreted as the next attrs's lead comment?
+		},
+		{
+			`
+test_attribute = foo /* multi-line
+                        comment in a weird place
+                     */
+`,
+			` /* multi-line
+                        comment in a weird place
+                     */`, //why did this newline get swallowed when others didn't?
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.want, func(t *testing.T) {
+			f, diags := ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != 0 {
+				for _, diag := range diags {
+					t.Logf("- %s", diag.Error())
+				}
+				t.Fatalf("unexpected diagnostics")
+			}
+			attr := f.Body().Attributes()["test_attribute"]
+			got := string(attr.LineComments().Bytes())
+			if got != test.want {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", got, test.want)
+			}
+		})
+	}
+}

--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -71,6 +71,10 @@ func (b *Block) Body() *Body {
 	return b.body.content.(*Body)
 }
 
+func (a *Block) LeadComments() Tokens {
+	return a.leadComments.content.BuildTokens(nil)
+}
+
 // Type returns the type name of the block.
 func (b *Block) Type() string {
 	typeNameObj := b.typeName.content.(*identifier)

--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -71,8 +71,8 @@ func (b *Block) Body() *Body {
 	return b.body.content.(*Body)
 }
 
-func (a *Block) LeadComments() Tokens {
-	return a.leadComments.content.BuildTokens(nil)
+func (b *Block) LeadComments() Tokens {
+	return b.leadComments.content.BuildTokens(nil)
 }
 
 // Type returns the type name of the block.

--- a/hclwrite/ast_block_test.go
+++ b/hclwrite/ast_block_test.go
@@ -488,4 +488,71 @@ func TestBlockSetLabels(t *testing.T) {
 	}
 }
 
-func TestBlockLineComments(t *testing.T) {}
+func TestBlockLeadComments(t *testing.T) {
+	tests := []struct {
+		src         string
+		wantComment string
+	}{
+		{
+			`# block comment
+block "test" {}
+`,
+			"# block comment\n",
+		},
+		{
+			`// block comment
+block "test" {}
+`,
+			"// block comment\n",
+		},
+		{
+			`// block comment
+// that goes on a bit
+// for fun
+block "test" {}
+`,
+			"// block comment\n// that goes on a bit\n// for fun\n",
+		},
+		// Terraform accepts multi-line go-style comments, but hclwrite does not consistently support this style comment.
+		{
+			`/* multiline
+comment
+*/
+block "test" {}
+`,
+			"", // unsupported
+		}, {
+			`/* multiline
+comment
+*/
+block "test" {}
+`,
+			"", // unsupported
+		},
+		{
+			`/* multiline comment, single line */
+block "test" {}
+`,
+			"", // unsupported
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.wantComment, func(t *testing.T) {
+			f := mustParseConfig(test.src)
+			b := f.Body().FirstMatchingBlock("block", []string{"test"})
+			got := string(b.LeadComments().Bytes())
+			if got != test.wantComment {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", got, test.wantComment)
+			}
+		})
+	}
+}
+
+func mustParseConfig(src string) *File {
+	f, diags := ParseConfig([]byte(src), "", hcl.Pos{Line: 1, Column: 1})
+	if len(diags) != 0 {
+		panic(diags.Error)
+	}
+	return f
+}

--- a/hclwrite/ast_block_test.go
+++ b/hclwrite/ast_block_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/ast_block_test.go
+++ b/hclwrite/ast_block_test.go
@@ -487,3 +487,5 @@ func TestBlockSetLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockLineComments(t *testing.T) {}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

This change exports functions from the `hclwrite` package to read comments.