### PR TITLE
hclwrite: `Block.SetType` sets type

### DIFF
--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -81,7 +81,7 @@ func (b *Block) Type() string {
 func (b *Block) SetType(typeName string) {
 	nameTok := newIdentToken(typeName)
 	nameObj := newIdentifier(nameTok)
-	b.typeName.ReplaceWith(nameObj)
+	b.typeName = b.typeName.ReplaceWith(nameObj)
 }
 
 // Labels returns the labels of the block.

--- a/hclwrite/ast_block_test.go
+++ b/hclwrite/ast_block_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/ast_block_test.go
+++ b/hclwrite/ast_block_test.go
@@ -138,7 +138,7 @@ blank "" {
 	}
 }
 
-func TestBlockSetType(t *testing.T) {
+func TestBlockSetType_buildTokens(t *testing.T) {
 	tests := []struct {
 		src         string
 		oldTypeName string
@@ -195,6 +195,27 @@ func TestBlockSetType(t *testing.T) {
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
 			}
 		})
+	}
+}
+
+func TestBlockSetType(t *testing.T) {
+	tests := []struct {
+		oldTypeName string
+		newTypeName string
+	}{
+		{
+			"foo",
+			"bar",
+		},
+	}
+
+	for _, test := range tests {
+		b := NewBlock(test.oldTypeName, nil)
+		b.SetType(test.newTypeName)
+
+		if b.Type() != test.newTypeName {
+			t.Errorf("wrong result\ngot: %s\nwant: %s\n", b.Type(), test.newTypeName)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

This change updates `hclwrite.Block.SetType()` for correctness of subsequent `hclwrite.Block.Type()` value retrieval.