### PR TITLE
hclwrite: parse object-construct expressions

### DIFF
--- a/hclwrite/ast_expression.go
+++ b/hclwrite/ast_expression.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/ast_expression.go
+++ b/hclwrite/ast_expression.go
@@ -187,6 +187,18 @@ Traversals:
 	}
 }
 
+func (e *Expression) AsObjectConsExpr() *ObjectConsExpr {
+	var found *ObjectConsExpr
+	e.walkChildNodes(func(n *node) {
+		if o, ok := n.content.(*ObjectConsExpr); ok {
+			found = o
+			return
+		}
+	})
+
+	return found
+}
+
 // Traversal represents a sequence of variable, attribute, and/or index
 // operations.
 type Traversal struct {

--- a/hclwrite/ast_expression.go
+++ b/hclwrite/ast_expression.go
@@ -15,6 +15,7 @@ type Expression struct {
 	inTree
 
 	absTraversals nodeSet
+	wrapped       *node
 }
 
 func newExpression() *Expression {
@@ -22,6 +23,15 @@ func newExpression() *Expression {
 		inTree:        newInTree(),
 		absTraversals: newNodeSet(),
 	}
+}
+
+func (e *Expression) wrap(c nodeContent) {
+	if e.wrapped != nil {
+		panic("this is a problem")
+	}
+
+	e.wrapped = newNode(c)
+	e.children.AppendNode(e.wrapped)
 }
 
 // NewExpressionRaw constructs an expression containing the given raw tokens.
@@ -188,15 +198,35 @@ Traversals:
 }
 
 func (e *Expression) AsObjectConsExpr() *ObjectConsExpr {
-	var found *ObjectConsExpr
-	e.walkChildNodes(func(n *node) {
-		if o, ok := n.content.(*ObjectConsExpr); ok {
-			found = o
-			return
-		}
-	})
+	if e.wrapped == nil {
+		return nil
+	}
 
-	return found
+	if object, ok := e.wrapped.content.(*ObjectConsExpr); ok {
+		return object
+	}
+
+	return nil
+}
+
+func (e *Expression) asQuoted() *quoted {
+	if e.wrapped == nil {
+		return nil
+	}
+
+	if quoted, ok := e.wrapped.content.(*quoted); ok {
+		return quoted
+	}
+
+	return nil
+}
+
+func (e *Expression) AsQuotedLiteral() Tokens {
+	if quoted := e.asQuoted(); quoted == nil {
+		return Tokens{}
+	} else {
+		return quoted.tokens
+	}
 }
 
 // Traversal represents a sequence of variable, attribute, and/or index

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -18,8 +18,16 @@ func (o *ObjectConsExpr) ValueFor(key string) *ObjectConsValue {
 	o.walkChildNodes(func(n *node) {
 		if item, ok := n.content.(*ObjectConsItem); ok {
 			k := item.key.content.(*ObjectConsKey)
-			name := k.name.content.(*identifier)
-			if k.literal && string(name.token.Bytes) == key {
+			name := k.name.content.(*Expression)
+
+			// A temporary workaround for parsing expressions as names at ...
+			// parse-time
+			maybeKey := ""
+			for _, token := range name.BuildTokens(nil) {
+				maybeKey += string(token.Bytes) // no spaces before
+			}
+
+			if k.literal && (maybeKey == key || maybeKey == `"`+key+`"`) {
 				found = item.value.content.(*ObjectConsValue)
 				return
 			}

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -1,0 +1,76 @@
+package hclwrite
+
+type ObjectConsExpr struct {
+	inTree
+}
+
+func newObjectConsExpr() *ObjectConsExpr {
+	return &ObjectConsExpr{
+		inTree: newInTree(),
+	}
+}
+
+func (o *ObjectConsExpr) ValueFor(key string) *ObjectConsValue {
+	var found *ObjectConsValue
+	o.walkChildNodes(func(n *node) {
+		if item, ok := n.content.(*ObjectConsItem); ok {
+			k := item.key.content.(*ObjectConsKey)
+			name := k.name.content.(*identifier)
+			if k.literal && string(name.token.Bytes) == key {
+				found = item.value.content.(*ObjectConsValue)
+				return
+			}
+		}
+	})
+	return found
+}
+
+type ObjectConsItem struct {
+	inTree
+	key   *node
+	value *node
+}
+
+func newObjectConsItem() *ObjectConsItem {
+	item := &ObjectConsItem{
+		inTree: newInTree(),
+		key:    newNode(newObjectConsKey()),
+		value:  newNode(newObjectConsValue()),
+	}
+	item.children.AppendNode(item.key)
+	item.children.AppendNode(item.value)
+
+	return item
+}
+
+func (item *ObjectConsItem) kv() (*ObjectConsKey, *ObjectConsValue) {
+	return item.key.content.(*ObjectConsKey), item.value.content.(*ObjectConsValue)
+}
+
+type ObjectConsKey struct {
+	inTree
+
+	literal bool
+	name    *node
+}
+
+func newObjectConsKey() *ObjectConsKey {
+	return &ObjectConsKey{
+		inTree: newInTree(),
+	}
+}
+
+type ObjectConsValue struct {
+	inTree
+	expr *node
+}
+
+func newObjectConsValue() *ObjectConsValue {
+	return &ObjectConsValue{
+		inTree: newInTree(),
+	}
+}
+
+func (o *ObjectConsValue) Expr() *Expression {
+	return o.expr.content.(*Expression)
+}

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -3,37 +3,40 @@
 
 package hclwrite
 
+import "strings"
+
 type ObjectConsExpr struct {
 	inTree
+
+	items nodeSet
 }
 
 func newObjectConsExpr() *ObjectConsExpr {
 	return &ObjectConsExpr{
 		inTree: newInTree(),
+		items:  newNodeSet(),
 	}
 }
 
 func (o *ObjectConsExpr) ValueFor(key string) *ObjectConsValue {
-	var found *ObjectConsValue
-	o.walkChildNodes(func(n *node) {
+	for _, n := range o.items.List() {
 		if item, ok := n.content.(*ObjectConsItem); ok {
-			k := item.key.content.(*ObjectConsKey)
+			k := item.key.content.(*ObjectConsKeyExpr)
 
-			maybeKey := k.literalName
-			if maybeKey == key || maybeKey == `"`+key+`"` {
-				found = item.value.content.(*ObjectConsValue)
-				return
+			maybeKey := k.String()
+			if maybeKey == key {
+				return item.value.content.(*ObjectConsValue)
 			}
 		}
-	})
-	return found
+	}
+
+	return nil
 }
 
 type ObjectConsItem struct {
 	inTree
-	key        *node
-	value      *node
-	literalKey string
+	key   *node
+	value *node
 }
 
 func newObjectConsItem() *ObjectConsItem {
@@ -42,17 +45,37 @@ func newObjectConsItem() *ObjectConsItem {
 	}
 }
 
-type ObjectConsKey struct {
+type ObjectConsKeyExpr struct {
 	inTree
 
 	literalName string
-	expr        *node
+	wrapped     *node
 }
 
-func newObjectConsKey() *ObjectConsKey {
-	return &ObjectConsKey{
-		inTree: newInTree(),
+func newObjectConsKeyExpr(wrapped *node) *ObjectConsKeyExpr {
+	expr := &ObjectConsKeyExpr{
+		inTree:  newInTree(),
+		wrapped: wrapped,
 	}
+	expr.children.AppendNode(wrapped)
+
+	return expr
+}
+
+func (k *ObjectConsKeyExpr) String() string {
+	if k.wrapped == nil {
+		return ""
+	}
+
+	if t, ok := k.wrapped.content.(*Traversal); ok && len(t.steps.List()) > 0 {
+		var b strings.Builder
+		tok := t.steps.List()[0].BuildTokens(nil)
+		tok.WriteTo(&b)
+
+		return b.String()
+	}
+
+	return ""
 }
 
 type ObjectConsValue struct {

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package hclwrite
 
 type ObjectConsExpr struct {

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -53,6 +53,7 @@ type ObjectConsKey struct {
 
 	literal bool
 	name    *node
+	expr    *node
 }
 
 func newObjectConsKey() *ObjectConsKey {

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -48,10 +48,6 @@ func newObjectConsItem() *ObjectConsItem {
 	}
 }
 
-func (item *ObjectConsItem) kv() (*ObjectConsKey, *ObjectConsValue) {
-	return item.key.content.(*ObjectConsKey), item.value.content.(*ObjectConsValue)
-}
-
 type ObjectConsKey struct {
 	inTree
 

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -48,8 +48,7 @@ func newObjectConsItem() *ObjectConsItem {
 type ObjectConsKeyExpr struct {
 	inTree
 
-	literalName string
-	wrapped     *node
+	wrapped *node
 }
 
 func newObjectConsKeyExpr(wrapped *node) *ObjectConsKeyExpr {
@@ -70,6 +69,8 @@ func (k *ObjectConsKeyExpr) String() string {
 	if t, ok := k.wrapped.content.(*Traversal); ok && len(t.steps.List()) > 0 {
 		var b strings.Builder
 		tok := t.steps.List()[0].BuildTokens(nil)
+
+		//nolint:errcheck // strings.Builder returns no error
 		tok.WriteTo(&b)
 
 		return b.String()

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -18,16 +18,9 @@ func (o *ObjectConsExpr) ValueFor(key string) *ObjectConsValue {
 	o.walkChildNodes(func(n *node) {
 		if item, ok := n.content.(*ObjectConsItem); ok {
 			k := item.key.content.(*ObjectConsKey)
-			name := k.name.content.(*Expression)
 
-			// A temporary workaround for parsing expressions as names at ...
-			// parse-time
-			maybeKey := ""
-			for _, token := range name.BuildTokens(nil) {
-				maybeKey += string(token.Bytes) // no spaces before
-			}
-
-			if k.literal && (maybeKey == key || maybeKey == `"`+key+`"`) {
+			maybeKey := k.literalName
+			if maybeKey == key || maybeKey == `"`+key+`"` {
 				found = item.value.content.(*ObjectConsValue)
 				return
 			}
@@ -38,8 +31,9 @@ func (o *ObjectConsExpr) ValueFor(key string) *ObjectConsValue {
 
 type ObjectConsItem struct {
 	inTree
-	key   *node
-	value *node
+	key        *node
+	value      *node
+	literalKey string
 }
 
 func newObjectConsItem() *ObjectConsItem {
@@ -51,9 +45,8 @@ func newObjectConsItem() *ObjectConsItem {
 type ObjectConsKey struct {
 	inTree
 
-	literal bool
-	name    *node
-	expr    *node
+	literalName string
+	expr        *node
 }
 
 func newObjectConsKey() *ObjectConsKey {

--- a/hclwrite/ast_object_cons_expr.go
+++ b/hclwrite/ast_object_cons_expr.go
@@ -43,15 +43,9 @@ type ObjectConsItem struct {
 }
 
 func newObjectConsItem() *ObjectConsItem {
-	item := &ObjectConsItem{
+	return &ObjectConsItem{
 		inTree: newInTree(),
-		key:    newNode(newObjectConsKey()),
-		value:  newNode(newObjectConsValue()),
 	}
-	item.children.AppendNode(item.key)
-	item.children.AppendNode(item.value)
-
-	return item
 }
 
 func (item *ObjectConsItem) kv() (*ObjectConsKey, *ObjectConsValue) {

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -427,7 +427,7 @@ func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens)
 		value.children.AppendNode(value.expr)
 		item.value = item.children.Append(value)
 
-		children.Append(item)
+		expr.items.Add(children.Append(item))
 	}
 
 	_, from, _ = from.Partition(nativeExpr.Range())

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -415,18 +415,10 @@ func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens)
 		nativeKeyExpr := nativeItem.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
 		key.literal = !nativeKeyExpr.ForceNonLiteral
 
-		if key.literal {
-			var keyToken *Token
-			before, keyToken, from = from.PartitionTypeSingle(hclsyntax.TokenIdent)
-
-			key.children.AppendUnstructuredTokens(before.writerTokens)
-			key.name = key.children.Append(newIdentifier(keyToken))
-		} else {
-			before, keyTokens, from = from.Partition(nativeKeyExpr.Range())
-
-			key.children.AppendUnstructuredTokens(before.writerTokens)
-			key.children.AppendNode(parseExpression(nativeKeyExpr, keyTokens))
-		}
+		before, keyTokens, from = from.Partition(nativeKeyExpr.Range())
+		key.children.AppendUnstructuredTokens(before.writerTokens)
+		key.name = parseExpression(nativeKeyExpr, keyTokens)
+		key.children.AppendNode(key.name)
 
 		before, valueTokens, from = from.Partition(nativeItem.ValueExpr.Range())
 		value.children.AppendUnstructuredTokens(before.writerTokens)

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -6,7 +6,6 @@ package hclwrite
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -387,55 +386,32 @@ func parseExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node {
 		return parseObjectConsKeyExpr(tNativeExpr, from)
 
 	case *hclsyntax.TemplateExpr:
-		if tNativeExpr.IsStringLiteral() {
-			quoted := newQuoted(from.writerTokens)
-
-			// Wrap in an Expression
-			wrapExpr := newExpression()
-			wrapExpr.children.Append(quoted)
-			return newNode(wrapExpr)
-		} else {
-			return parseAnyExpression(nativeExpr, from)
-		}
+		return parseTemplateExpr(tNativeExpr, from)
 
 	default:
 		return parseAnyExpression(nativeExpr, from)
 	}
 }
 
-// parseObjectConsExpr parses an object-construct key expression.
-// An object key is an Identifier or an Expression. In this context, a quoted
-// literal is functionally equivalent to an Identifier.
-func parseObjectConsKeyExpr(nativeExpr *hclsyntax.ObjectConsKeyExpr, from inputTokens) *node {
-	wrapExpr := newObjectConsKey()
+func parseAnyExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node {
+	expr := newExpression()
+	children := expr.children
 
-	if nativeExpr.ForceNonLiteral {
-		expr := parseExpression(nativeExpr.Wrapped, from)
+	nativeVars := nativeExpr.Variables()
 
-		wrapExpr.expr = expr
-		wrapExpr.children.AppendNode(expr)
-
-	} else {
-		if templateExpr, ok := nativeExpr.Wrapped.(*hclsyntax.TemplateExpr); ok && templateExpr.IsStringLiteral() {
-			literalValueExpr := templateExpr.Parts[0].(*hclsyntax.LiteralValueExpr)
-
-			quoted := newQuoted(from.writerTokens)
-			_, literal, _ := from.Partition(literalValueExpr.Range())
-
-			var b strings.Builder
-			literal.writerTokens.WriteTo(&b)
-			wrapExpr.literalName = b.String()
-			wrapExpr.children.Append(quoted)
-		} else if scopeTraversalExpr, ok := nativeExpr.Wrapped.(*hclsyntax.ScopeTraversalExpr); ok {
-			traversal := scopeTraversalExpr.AsTraversal()
-			expr := NewExpressionAbsTraversal(traversal)
-
-			wrapExpr.literalName = traversal.RootName()
-			wrapExpr.children.Append(expr)
-		}
+	for _, nativeTraversal := range nativeVars {
+		before, traversal, after := parseTraversal(nativeTraversal, from)
+		children.AppendUnstructuredTokens(before.Tokens())
+		children.AppendNode(traversal)
+		expr.absTraversals.Add(traversal)
+		from = after
 	}
+	// Attach any stragglers that don't belong to a traversal to the expression
+	// itself. In an expression with no traversals at all, this is just the
+	// entirety of "from".
+	children.AppendUnstructuredTokens(from.Tokens())
 
-	return newNode(wrapExpr)
+	return newNode(expr)
 }
 
 // parseObjectConsExpr parses an object-construct expression, defined as:
@@ -475,9 +451,9 @@ func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens)
 		value.expr = parseExpression(nativeItem.ValueExpr, valueTokens)
 		value.children.AppendNode(value.expr)
 		item.value = item.children.Append(value)
-		item.literalKey = item.key.content.(*ObjectConsKey).literalName
 
-		expr.children.Append(item)
+		node := expr.children.Append(item)
+		expr.items.Add(node)
 	}
 
 	_, from, _ = from.Partition(nativeExpr.Range())
@@ -485,29 +461,30 @@ func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens)
 
 	// Wrap in an Expression
 	wrapExpr := newExpression()
-	wrapExpr.children.Append(expr)
+	wrapExpr.wrap(expr)
 	return newNode(wrapExpr)
 }
 
-func parseAnyExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node {
-	expr := newExpression()
-	children := expr.children
+// parseObjectConsExpr parses an object-construct key expression.
+// An object key is an Identifier or an Expression. In this context, a quoted
+// literal is functionally equivalent to an Identifier.
+func parseObjectConsKeyExpr(nativeExpr *hclsyntax.ObjectConsKeyExpr, from inputTokens) *node {
+	expr := parseExpression(nativeExpr.Wrapped, from)
+	wrapExpr := newObjectConsKeyExpr(expr)
 
-	nativeVars := nativeExpr.Variables()
+	return newNode(wrapExpr)
+}
 
-	for _, nativeTraversal := range nativeVars {
-		before, traversal, after := parseTraversal(nativeTraversal, from)
-		children.AppendUnstructuredTokens(before.Tokens())
-		children.AppendNode(traversal)
-		expr.absTraversals.Add(traversal)
-		from = after
+func parseTemplateExpr(nativeExpr *hclsyntax.TemplateExpr, from inputTokens) *node {
+	if nativeExpr.IsStringLiteral() {
+		quoted := newQuoted(from.writerTokens)
+
+		expr := newExpression()
+		expr.wrapped = expr.children.Append(quoted)
+		return newNode(expr)
+	} else {
+		return parseAnyExpression(nativeExpr, from)
 	}
-	// Attach any stragglers that don't belong to a traversal to the expression
-	// itself. In an expression with no traversals at all, this is just the
-	// entirety of "from".
-	children.AppendUnstructuredTokens(from.Tokens())
-
-	return newNode(expr)
 }
 
 func parseTraversal(nativeTraversal hcl.Traversal, from inputTokens) (before inputTokens, n *node, after inputTokens) {

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -422,9 +422,6 @@ func parseAnyExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node
 //	objectelem = (Identifier | Expression) ("=" | ":") Expression;
 //
 // It leaves any lead comments and line comments as unstructed tokens.
-//
-// It returns *Expression. The returned *Expression has a child *ObjectConsExpr
-// that can be unwrapped via Expression.AsObjectConsExpr().
 func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens) *node {
 	expr := newObjectConsExpr()
 	children := expr.children

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -421,7 +421,7 @@ func parseAnyExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node
 //	) "}";
 //	objectelem = (Identifier | Expression) ("=" | ":") Expression;
 //
-// It leaves any lead comments and line comments as unstructed tokens.
+// It leaves any lead comments and line comments as unstructured tokens.
 func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens) *node {
 	expr := newObjectConsExpr()
 	children := expr.children

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -410,20 +410,22 @@ func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens)
 
 	for _, nativeItem := range nativeExpr.Items {
 		item := newObjectConsItem()
-		key, value := item.kv()
+		key, value := newObjectConsKey(), newObjectConsValue()
 
 		nativeKeyExpr := nativeItem.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
 		key.literal = !nativeKeyExpr.ForceNonLiteral
 
 		before, keyTokens, from = from.Partition(nativeKeyExpr.Range())
-		key.children.AppendUnstructuredTokens(before.writerTokens)
+		item.children.AppendUnstructuredTokens(before.writerTokens)
 		key.name = parseExpression(nativeKeyExpr, keyTokens)
 		key.children.AppendNode(key.name)
+		item.key = item.children.Append(key)
 
 		before, valueTokens, from = from.Partition(nativeItem.ValueExpr.Range())
-		value.children.AppendUnstructuredTokens(before.writerTokens)
+		item.children.AppendUnstructuredTokens(before.writerTokens)
 		value.expr = parseExpression(nativeItem.ValueExpr, valueTokens)
 		value.children.AppendNode(value.expr)
+		item.value = item.children.Append(value)
 
 		children.Append(item)
 	}

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -376,6 +376,76 @@ func parseBlockLabels(nativeBlock *hclsyntax.Block, from inputTokens) (inputToke
 }
 
 func parseExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node {
+	switch tNativeExpr := nativeExpr.(type) {
+
+	// Object-construct expression
+	case *hclsyntax.ObjectConsExpr:
+		return parseObjectConsExpr(tNativeExpr, from)
+
+	default:
+		return parseAnyExpression(nativeExpr, from)
+	}
+}
+
+// parseObjectConsExpr parses an object-construct expression, defined as:
+//
+//	object = "{" (
+//	    (objectelem (( "," | Newline) objectelem)* ","?)?
+//	) "}";
+//	objectelem = (Identifier | Expression) ("=" | ":") Expression;
+//
+// It leaves any lead comments and line comments as unstructed tokens.
+//
+// It returns *Expression. The returned *Expression has a child *ObjectConsExpr
+// that can be unwrapped via Expression.AsObjectConsExpr().
+func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens) *node {
+	expr := newObjectConsExpr()
+	children := expr.children
+
+	var before, open, keyTokens, valueTokens inputTokens
+
+	before, open, from = from.Partition(nativeExpr.StartRange())
+	children.AppendUnstructuredTokens(before.writerTokens)
+	children.AppendUnstructuredTokens(open.writerTokens)
+
+	for _, nativeItem := range nativeExpr.Items {
+		item := newObjectConsItem()
+		key, value := item.kv()
+
+		nativeKeyExpr := nativeItem.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
+		key.literal = !nativeKeyExpr.ForceNonLiteral
+
+		if key.literal {
+			var keyToken *Token
+			before, keyToken, from = from.PartitionTypeSingle(hclsyntax.TokenIdent)
+
+			key.children.AppendUnstructuredTokens(before.writerTokens)
+			key.name = key.children.Append(newIdentifier(keyToken))
+		} else {
+			before, keyTokens, from = from.Partition(nativeKeyExpr.Range())
+
+			key.children.AppendUnstructuredTokens(before.writerTokens)
+			key.children.AppendNode(parseExpression(nativeKeyExpr, keyTokens))
+		}
+
+		before, valueTokens, from = from.Partition(nativeItem.ValueExpr.Range())
+		value.children.AppendUnstructuredTokens(before.writerTokens)
+		value.expr = parseExpression(nativeItem.ValueExpr, valueTokens)
+		value.children.AppendNode(value.expr)
+
+		children.Append(item)
+	}
+
+	_, from, _ = from.Partition(nativeExpr.Range())
+	children.AppendUnstructuredTokens(from.writerTokens)
+
+	// Wrap in an Expression
+	wrapExpr := newExpression()
+	wrapExpr.children.Append(expr)
+	return newNode(wrapExpr)
+}
+
+func parseAnyExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node {
 	expr := newExpression()
 	children := expr.children
 

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -427,7 +427,7 @@ func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens)
 		value.children.AppendNode(value.expr)
 		item.value = item.children.Append(value)
 
-		expr.items.Add(children.Append(item))
+		expr.children.Append(item)
 	}
 
 	_, from, _ = from.Partition(nativeExpr.Range())

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -382,9 +382,44 @@ func parseExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node {
 	case *hclsyntax.ObjectConsExpr:
 		return parseObjectConsExpr(tNativeExpr, from)
 
+	case *hclsyntax.ObjectConsKeyExpr:
+		return parseObjectConsKeyExpr(tNativeExpr, from)
+
+	case *hclsyntax.TemplateExpr:
+		if tNativeExpr.IsStringLiteral() {
+			quoted := newQuoted(from.writerTokens)
+
+			// Wrap in an Expression
+			wrapExpr := newExpression()
+			wrapExpr.children.Append(quoted)
+			return newNode(wrapExpr)
+		} else {
+			return parseAnyExpression(nativeExpr, from)
+		}
+
 	default:
 		return parseAnyExpression(nativeExpr, from)
 	}
+}
+
+// parseObjectConsExpr parses an object-construct key expression
+func parseObjectConsKeyExpr(nativeExpr *hclsyntax.ObjectConsKeyExpr, from inputTokens) *node {
+	wrapExpr := newObjectConsKey()
+
+	if nativeExpr.ForceNonLiteral {
+		expr := parseExpression(nativeExpr.Wrapped, from)
+
+		wrapExpr.expr = expr
+		wrapExpr.children.AppendNode(expr)
+
+	} else {
+		quoted := newQuoted(from.writerTokens)
+
+		wrapExpr.literal = true
+		wrapExpr.name = wrapExpr.children.Append(quoted)
+	}
+
+	return newNode(wrapExpr)
 }
 
 // parseObjectConsExpr parses an object-construct expression, defined as:
@@ -410,16 +445,14 @@ func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens)
 
 	for _, nativeItem := range nativeExpr.Items {
 		item := newObjectConsItem()
-		key, value := newObjectConsKey(), newObjectConsValue()
+		value := newObjectConsValue()
 
 		nativeKeyExpr := nativeItem.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
-		key.literal = !nativeKeyExpr.ForceNonLiteral
 
 		before, keyTokens, from = from.Partition(nativeKeyExpr.Range())
 		item.children.AppendUnstructuredTokens(before.writerTokens)
-		key.name = parseExpression(nativeKeyExpr, keyTokens)
-		key.children.AppendNode(key.name)
-		item.key = item.children.Append(key)
+		item.key = parseObjectConsKeyExpr(nativeKeyExpr, keyTokens)
+		item.children.AppendNode(item.key)
 
 		before, valueTokens, from = from.Partition(nativeItem.ValueExpr.Range())
 		item.children.AppendUnstructuredTokens(before.writerTokens)

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -6,6 +6,7 @@ package hclwrite
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -402,7 +403,9 @@ func parseExpression(nativeExpr hclsyntax.Expression, from inputTokens) *node {
 	}
 }
 
-// parseObjectConsExpr parses an object-construct key expression
+// parseObjectConsExpr parses an object-construct key expression.
+// An object key is an Identifier or an Expression. In this context, a quoted
+// literal is functionally equivalent to an Identifier.
 func parseObjectConsKeyExpr(nativeExpr *hclsyntax.ObjectConsKeyExpr, from inputTokens) *node {
 	wrapExpr := newObjectConsKey()
 
@@ -413,10 +416,23 @@ func parseObjectConsKeyExpr(nativeExpr *hclsyntax.ObjectConsKeyExpr, from inputT
 		wrapExpr.children.AppendNode(expr)
 
 	} else {
-		quoted := newQuoted(from.writerTokens)
+		if templateExpr, ok := nativeExpr.Wrapped.(*hclsyntax.TemplateExpr); ok && templateExpr.IsStringLiteral() {
+			literalValueExpr := templateExpr.Parts[0].(*hclsyntax.LiteralValueExpr)
 
-		wrapExpr.literal = true
-		wrapExpr.name = wrapExpr.children.Append(quoted)
+			quoted := newQuoted(from.writerTokens)
+			_, literal, _ := from.Partition(literalValueExpr.Range())
+
+			var b strings.Builder
+			literal.writerTokens.WriteTo(&b)
+			wrapExpr.literalName = b.String()
+			wrapExpr.children.Append(quoted)
+		} else if scopeTraversalExpr, ok := nativeExpr.Wrapped.(*hclsyntax.ScopeTraversalExpr); ok {
+			traversal := scopeTraversalExpr.AsTraversal()
+			expr := NewExpressionAbsTraversal(traversal)
+
+			wrapExpr.literalName = traversal.RootName()
+			wrapExpr.children.Append(expr)
+		}
 	}
 
 	return newNode(wrapExpr)
@@ -459,6 +475,7 @@ func parseObjectConsExpr(nativeExpr *hclsyntax.ObjectConsExpr, from inputTokens)
 		value.expr = parseExpression(nativeItem.ValueExpr, valueTokens)
 		value.children.AppendNode(value.expr)
 		item.value = item.children.Append(value)
+		item.literalKey = item.key.content.(*ObjectConsKey).literalName
 
 		expr.children.Append(item)
 	}

--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -475,6 +475,8 @@ func parseObjectConsKeyExpr(nativeExpr *hclsyntax.ObjectConsKeyExpr, from inputT
 	return newNode(wrapExpr)
 }
 
+// parseObjectConsExpr is specifically interested in string literal expressions
+// at this time.
 func parseTemplateExpr(nativeExpr *hclsyntax.TemplateExpr, from inputTokens) *node {
 	if nativeExpr.IsStringLiteral() {
 		quoted := newQuoted(from.writerTokens)

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -1238,7 +1238,7 @@ func TestParse(t *testing.T) {
 														Val:  "\n",
 													},
 													{
-														Type: "ObjectConsKey",
+														Type: "ObjectConsKeyExpr",
 														Children: []TestTreeNode{
 															{
 																Type: "Expression",
@@ -1252,7 +1252,7 @@ func TestParse(t *testing.T) {
 																				Children: []TestTreeNode{
 																					{
 																						Type: "identifier",
-																						Val:  "hat",
+																						Val:  "    hat",
 																					},
 																				},
 																			},
@@ -1290,7 +1290,7 @@ func TestParse(t *testing.T) {
 														Val:  ",",
 													},
 													{
-														Type: "ObjectConsKey",
+														Type: "ObjectConsKeyExpr",
 														Children: []TestTreeNode{
 															{
 																Type: "Expression",
@@ -1303,8 +1303,13 @@ func TestParse(t *testing.T) {
 																		Type: "Traversal",
 																		Children: []TestTreeNode{
 																			{
-																				Type:     "TraverseName",
-																				Children: []TestTreeNode{{Type: "identifier", Val: "cat"}},
+																				Type: "TraverseName",
+																				Children: []TestTreeNode{
+																					{
+																						Type: "identifier",
+																						Val:  "cat",
+																					},
+																				},
 																			},
 																		},
 																	},
@@ -1392,7 +1397,7 @@ func TestParse(t *testing.T) {
 														Val:  "\n",
 													},
 													{
-														Type: "ObjectConsKey",
+														Type: "ObjectConsKeyExpr",
 														Children: []TestTreeNode{
 															{
 																Type: "Expression",
@@ -1406,7 +1411,7 @@ func TestParse(t *testing.T) {
 																				Children: []TestTreeNode{
 																					{
 																						Type: "identifier",
-																						Val:  "hat",
+																						Val:  "    hat",
 																					},
 																				},
 																			},
@@ -1444,7 +1449,7 @@ func TestParse(t *testing.T) {
 														Val:  " // a fancy hat\n",
 													},
 													{
-														Type: "ObjectConsKey",
+														Type: "ObjectConsKeyExpr",
 														Children: []TestTreeNode{
 															{
 																Type: "Expression",
@@ -1544,10 +1549,16 @@ func TestParse(t *testing.T) {
 														Val:  "\n",
 													},
 													{
-														Type: "ObjectConsKey",
+														Type: "ObjectConsKeyExpr",
 														Children: []TestTreeNode{
 															{
-																Type: "quoted", Val: `    "hat"`,
+																Type: "Expression",
+																Children: []TestTreeNode{
+																	{
+																		Type: "quoted",
+																		Val:  `    "hat"`,
+																	},
+																},
 															},
 														},
 													},

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -1241,8 +1241,10 @@ func TestParse(t *testing.T) {
 																Val:  "\n",
 															},
 															{
-																Type: "identifier",
-																Val:  "    hat",
+																Type: "Expression",
+																Children: []TestTreeNode{{
+																	Type: "Tokens", Val: "    hat",
+																}},
 															},
 														},
 													},
@@ -1379,8 +1381,10 @@ func TestParse(t *testing.T) {
 																Val:  "\n",
 															},
 															{
-																Type: "identifier",
-																Val:  "    hat",
+																Type: "Expression",
+																Children: []TestTreeNode{{
+																	Type: "Tokens", Val: "    hat",
+																}},
 															},
 														},
 													},

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -1234,12 +1234,12 @@ func TestParse(t *testing.T) {
 												Type: "ObjectConsItem",
 												Children: []TestTreeNode{
 													{
+														Type: "Tokens",
+														Val:  "\n",
+													},
+													{
 														Type: "ObjectConsKey",
 														Children: []TestTreeNode{
-															{
-																Type: "Tokens",
-																Val:  "\n",
-															},
 															{
 																Type: "Expression",
 																Children: []TestTreeNode{{
@@ -1249,12 +1249,12 @@ func TestParse(t *testing.T) {
 														},
 													},
 													{
+														Type: "Tokens",
+														Val:  " =",
+													},
+													{
 														Type: "ObjectConsValue",
 														Children: []TestTreeNode{
-															{
-																Type: "Tokens",
-																Val:  " =",
-															},
 															{
 																Type: "Expression",
 																Children: []TestTreeNode{
@@ -1272,12 +1272,12 @@ func TestParse(t *testing.T) {
 												Type: "ObjectConsItem",
 												Children: []TestTreeNode{
 													{
+														Type: "Tokens",
+														Val:  ",",
+													},
+													{
 														Type: "ObjectConsKey",
 														Children: []TestTreeNode{
-															{
-																Type: "Tokens",
-																Val:  ",",
-															},
 															{
 																Type: "Expression",
 																Children: []TestTreeNode{
@@ -1303,12 +1303,12 @@ func TestParse(t *testing.T) {
 														},
 													},
 													{
+														Type: "Tokens",
+														Val:  " =",
+													},
+													{
 														Type: "ObjectConsValue",
 														Children: []TestTreeNode{
-															{
-																Type: "Tokens",
-																Val:  " =",
-															},
 															{
 																Type: "Expression",
 																Children: []TestTreeNode{
@@ -1374,12 +1374,12 @@ func TestParse(t *testing.T) {
 												Type: "ObjectConsItem",
 												Children: []TestTreeNode{
 													{
+														Type: "Tokens",
+														Val:  "\n",
+													},
+													{
 														Type: "ObjectConsKey",
 														Children: []TestTreeNode{
-															{
-																Type: "Tokens",
-																Val:  "\n",
-															},
 															{
 																Type: "Expression",
 																Children: []TestTreeNode{{
@@ -1389,12 +1389,12 @@ func TestParse(t *testing.T) {
 														},
 													},
 													{
+														Type: "Tokens",
+														Val:  " =",
+													},
+													{
 														Type: "ObjectConsValue",
 														Children: []TestTreeNode{
-															{
-																Type: "Tokens",
-																Val:  " =",
-															},
 															{
 																Type: "Expression",
 																Children: []TestTreeNode{
@@ -1412,12 +1412,12 @@ func TestParse(t *testing.T) {
 												Type: "ObjectConsItem",
 												Children: []TestTreeNode{
 													{
+														Type: "Tokens",
+														Val:  " // a fancy hat\n",
+													},
+													{
 														Type: "ObjectConsKey",
 														Children: []TestTreeNode{
-															{
-																Type: "Tokens",
-																Val:  " // a fancy hat\n",
-															},
 															{
 																Type: "Expression",
 																Children: []TestTreeNode{
@@ -1443,12 +1443,12 @@ func TestParse(t *testing.T) {
 														},
 													},
 													{
+														Type: "Tokens",
+														Val:  " =",
+													},
+													{
 														Type: "ObjectConsValue",
 														Children: []TestTreeNode{
-															{
-																Type: "Tokens",
-																Val:  " =",
-															},
 															{
 																Type: "Expression",
 																Children: []TestTreeNode{

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -1512,6 +1512,178 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			`a = {
+  hat = {
+	style = "derby",
+	color = (variable)
+  },
+  cat = "calico"
+}`,
+			TestTreeNode{
+				Type: "Body",
+				Children: []TestTreeNode{{
+					Type: "Attribute",
+					Children: []TestTreeNode{
+						{Type: "comments"},
+						{Type: "identifier", Val: "a"},
+						{Type: "Tokens", Val: " ="},
+						{
+							Type: "Expression",
+							Children: []TestTreeNode{{
+								Type: "ObjectConsExpr",
+								Children: []TestTreeNode{
+									{Type: "Tokens", Val: " {"},
+									{
+										Type: "ObjectConsItem",
+										Children: []TestTreeNode{
+											{Type: "Tokens", Val: "\n"},
+											{
+												Type: "ObjectConsKeyExpr",
+												Children: []TestTreeNode{{
+													Type: "Expression",
+													Children: []TestTreeNode{{
+														Type: "Traversal",
+														Children: []TestTreeNode{
+															{
+																Type:     "TraverseName",
+																Children: []TestTreeNode{{Type: "identifier", Val: "  hat"}},
+															},
+														},
+													}},
+												}},
+											},
+											{Type: "Tokens", Val: " ="},
+											{
+												Type: "ObjectConsValue",
+												Children: []TestTreeNode{{
+													Type: "Expression",
+													Children: []TestTreeNode{{
+														Type: "ObjectConsExpr",
+														Children: []TestTreeNode{
+															{Type: "Tokens", Val: " {"},
+															{
+																Type: "ObjectConsItem",
+																Children: []TestTreeNode{
+																	{Type: "Tokens", Val: "\n"},
+																	{
+																		Type: "ObjectConsKeyExpr",
+																		Children: []TestTreeNode{
+																			{
+																				Type: "Expression",
+																				Children: []TestTreeNode{
+																					{
+																						Type: "Traversal",
+																						Children: []TestTreeNode{
+																							{
+																								Type: "TraverseName",
+																								Children: []TestTreeNode{
+																									{Type: "identifier", Val: " style"},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																	{Type: "Tokens", Val: " ="},
+																	{
+																		Type: "ObjectConsValue",
+																		Children: []TestTreeNode{
+																			{
+																				Type:     "Expression",
+																				Children: []TestTreeNode{{Type: "quoted", Val: ` "derby"`}},
+																			},
+																		},
+																	},
+																},
+															},
+															{
+																Type: "ObjectConsItem",
+																Children: []TestTreeNode{
+																	{Type: "Tokens", Val: ",\n"},
+																	{
+																		Type: "ObjectConsKeyExpr",
+																		Children: []TestTreeNode{{
+																			Type: "Expression",
+																			Children: []TestTreeNode{{
+																				Type: "Traversal", Children: []TestTreeNode{{
+																					Type:     "TraverseName",
+																					Children: []TestTreeNode{{Type: "identifier", Val: " color"}},
+																				}},
+																			}},
+																		}},
+																	},
+																	{Type: "Tokens", Val: " ="},
+																	{
+																		Type: "ObjectConsValue",
+																		Children: []TestTreeNode{{
+																			Type: "Expression",
+																			Children: []TestTreeNode{
+																				{Type: "Tokens", Val: " ("},
+																				{
+																					Type: "Traversal",
+																					Children: []TestTreeNode{{
+																						Type:     "TraverseName",
+																						Children: []TestTreeNode{{Type: "identifier", Val: "variable"}},
+																					}},
+																				},
+																				{Type: "Tokens", Val: ")"},
+																			},
+																		}},
+																	},
+																},
+															},
+															{Type: "Tokens", Val: "\n  }"},
+														},
+													}},
+												}},
+											},
+										},
+									},
+									{
+										Type: "ObjectConsItem",
+										Children: []TestTreeNode{
+											{Type: "Tokens", Val: ",\n"},
+											{
+												Type: "ObjectConsKeyExpr",
+												Children: []TestTreeNode{{
+													Type: "Expression",
+													Children: []TestTreeNode{
+														{
+															Type: "Traversal",
+															Children: []TestTreeNode{{
+																Type: "TraverseName",
+																Children: []TestTreeNode{
+																	{Type: "identifier", Val: "  cat"},
+																},
+															}},
+														},
+													},
+												}},
+											},
+											{Type: "Tokens", Val: " ="},
+											{
+												Type: "ObjectConsValue",
+												Children: []TestTreeNode{{
+													Type: "Expression",
+													Children: []TestTreeNode{
+														{Type: "quoted", Val: ` "calico"`},
+													},
+												}},
+											},
+										},
+									},
+									{Type: "Tokens", Val: "\n}"},
+								},
+							}},
+						},
+						{Type: "comments"},
+					},
+				}},
+			},
+		},
+		{
 			`zzz = {
 				"hat" = "derby" }`,
 			TestTreeNode{

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -1241,10 +1241,7 @@ func TestParse(t *testing.T) {
 														Type: "ObjectConsKey",
 														Children: []TestTreeNode{
 															{
-																Type: "Expression",
-																Children: []TestTreeNode{{
-																	Type: "Tokens", Val: "    hat",
-																}},
+																Type: "quoted", Val: "    hat",
 															},
 														},
 													},
@@ -1259,7 +1256,7 @@ func TestParse(t *testing.T) {
 																Type: "Expression",
 																Children: []TestTreeNode{
 																	{
-																		Type: "Tokens",
+																		Type: "quoted",
 																		Val:  ` "derby"`,
 																	},
 																},
@@ -1313,7 +1310,7 @@ func TestParse(t *testing.T) {
 																Type: "Expression",
 																Children: []TestTreeNode{
 																	{
-																		Type: "Tokens",
+																		Type: "quoted",
 																		Val:  ` "calico"`,
 																	},
 																},
@@ -1381,10 +1378,7 @@ func TestParse(t *testing.T) {
 														Type: "ObjectConsKey",
 														Children: []TestTreeNode{
 															{
-																Type: "Expression",
-																Children: []TestTreeNode{{
-																	Type: "Tokens", Val: "    hat",
-																}},
+																Type: "quoted", Val: "    hat",
 															},
 														},
 													},
@@ -1399,7 +1393,7 @@ func TestParse(t *testing.T) {
 																Type: "Expression",
 																Children: []TestTreeNode{
 																	{
-																		Type: "Tokens",
+																		Type: "quoted",
 																		Val:  ` "derby"`,
 																	},
 																},
@@ -1453,7 +1447,7 @@ func TestParse(t *testing.T) {
 																Type: "Expression",
 																Children: []TestTreeNode{
 																	{
-																		Type: "Tokens",
+																		Type: "quoted",
 																		Val:  ` "calico"`,
 																	},
 																},
@@ -1465,6 +1459,87 @@ func TestParse(t *testing.T) {
 											{
 												Type: "Tokens",
 												Val:  "\n   }",
+											},
+										},
+									},
+								},
+							},
+							{
+								Type: "comments",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			`zzz = {
+				"hat" = "derby" }`,
+			TestTreeNode{
+				Type: "Body",
+				Children: []TestTreeNode{
+					{
+						Type: "Attribute",
+						Children: []TestTreeNode{
+							{
+								Type: "comments",
+							},
+							{
+								Type: "identifier",
+								Val:  "zzz",
+							},
+							{
+								Type: "Tokens",
+								Val:  " =",
+							},
+							{
+								Type: "Expression",
+								Children: []TestTreeNode{
+									{
+										Type: "ObjectConsExpr",
+										Children: []TestTreeNode{
+											{
+												Type: "Tokens",
+												Val:  " {",
+											},
+											{
+												Type: "ObjectConsItem",
+												Children: []TestTreeNode{
+													{
+														Type: "Tokens",
+														Val:  "\n",
+													},
+													{
+														Type: "ObjectConsKey",
+														Children: []TestTreeNode{
+															{
+																Type: "quoted", Val: `    "hat"`,
+															},
+														},
+													},
+													{
+														Type: "Tokens",
+														Val:  " =",
+													},
+													{
+														Type: "ObjectConsValue",
+														Children: []TestTreeNode{
+															{
+																Type: "Expression",
+																Children: []TestTreeNode{
+																	{
+																		Type: "quoted",
+																		Val:  ` "derby"`,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											{
+												Type: "Tokens",
+												Val:  " }",
 											},
 										},
 									},

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -1241,7 +1241,24 @@ func TestParse(t *testing.T) {
 														Type: "ObjectConsKey",
 														Children: []TestTreeNode{
 															{
-																Type: "quoted", Val: "    hat",
+																Type: "Expression",
+																Children: []TestTreeNode{
+
+																	{
+																		Type: "Traversal",
+																		Children: []TestTreeNode{
+																			{
+																				Type: "TraverseName",
+																				Children: []TestTreeNode{
+																					{
+																						Type: "identifier",
+																						Val:  "hat",
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
 															},
 														},
 													},
@@ -1378,7 +1395,24 @@ func TestParse(t *testing.T) {
 														Type: "ObjectConsKey",
 														Children: []TestTreeNode{
 															{
-																Type: "quoted", Val: "    hat",
+																Type: "Expression",
+																Children: []TestTreeNode{
+
+																	{
+																		Type: "Traversal",
+																		Children: []TestTreeNode{
+																			{
+																				Type: "TraverseName",
+																				Children: []TestTreeNode{
+																					{
+																						Type: "identifier",
+																						Val:  "hat",
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
 															},
 														},
 													},

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -1200,6 +1200,280 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			`a = {
+				hat = "derby", (cat) = "calico" }`,
+			TestTreeNode{
+				Type: "Body",
+				Children: []TestTreeNode{
+					{
+						Type: "Attribute",
+						Children: []TestTreeNode{
+							{
+								Type: "comments",
+							},
+							{
+								Type: "identifier",
+								Val:  "a",
+							},
+							{
+								Type: "Tokens",
+								Val:  " =",
+							},
+							{
+								Type: "Expression",
+								Children: []TestTreeNode{
+									{
+										Type: "ObjectConsExpr",
+										Children: []TestTreeNode{
+											{
+												Type: "Tokens",
+												Val:  " {",
+											},
+											{
+												Type: "ObjectConsItem",
+												Children: []TestTreeNode{
+													{
+														Type: "ObjectConsKey",
+														Children: []TestTreeNode{
+															{
+																Type: "Tokens",
+																Val:  "\n",
+															},
+															{
+																Type: "identifier",
+																Val:  "    hat",
+															},
+														},
+													},
+													{
+														Type: "ObjectConsValue",
+														Children: []TestTreeNode{
+															{
+																Type: "Tokens",
+																Val:  " =",
+															},
+															{
+																Type: "Expression",
+																Children: []TestTreeNode{
+																	{
+																		Type: "Tokens",
+																		Val:  ` "derby"`,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											{
+												Type: "ObjectConsItem",
+												Children: []TestTreeNode{
+													{
+														Type: "ObjectConsKey",
+														Children: []TestTreeNode{
+															{
+																Type: "Tokens",
+																Val:  ",",
+															},
+															{
+																Type: "Expression",
+																Children: []TestTreeNode{
+																	{
+																		Type: "Tokens",
+																		Val:  " (",
+																	},
+																	{
+																		Type: "Traversal",
+																		Children: []TestTreeNode{
+																			{
+																				Type:     "TraverseName",
+																				Children: []TestTreeNode{{Type: "identifier", Val: "cat"}},
+																			},
+																		},
+																	},
+																	{
+																		Type: "Tokens",
+																		Val:  ")",
+																	},
+																},
+															},
+														},
+													},
+													{
+														Type: "ObjectConsValue",
+														Children: []TestTreeNode{
+															{
+																Type: "Tokens",
+																Val:  " =",
+															},
+															{
+																Type: "Expression",
+																Children: []TestTreeNode{
+																	{
+																		Type: "Tokens",
+																		Val:  ` "calico"`,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											{
+												Type: "Tokens",
+												Val:  " }",
+											},
+										},
+									},
+								},
+							},
+							{
+								Type: "comments",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			`a = {
+				hat = "derby" // a fancy hat
+		   	    (cat) = "calico"
+			}`,
+			TestTreeNode{
+				Type: "Body",
+				Children: []TestTreeNode{
+					{
+						Type: "Attribute",
+						Children: []TestTreeNode{
+							{
+								Type: "comments",
+							},
+							{
+								Type: "identifier",
+								Val:  "a",
+							},
+							{
+								Type: "Tokens",
+								Val:  " =",
+							},
+							{
+								Type: "Expression",
+								Children: []TestTreeNode{
+									{
+										Type: "ObjectConsExpr",
+										Children: []TestTreeNode{
+											{
+												Type: "Tokens",
+												Val:  " {",
+											},
+											{
+												Type: "ObjectConsItem",
+												Children: []TestTreeNode{
+													{
+														Type: "ObjectConsKey",
+														Children: []TestTreeNode{
+															{
+																Type: "Tokens",
+																Val:  "\n",
+															},
+															{
+																Type: "identifier",
+																Val:  "    hat",
+															},
+														},
+													},
+													{
+														Type: "ObjectConsValue",
+														Children: []TestTreeNode{
+															{
+																Type: "Tokens",
+																Val:  " =",
+															},
+															{
+																Type: "Expression",
+																Children: []TestTreeNode{
+																	{
+																		Type: "Tokens",
+																		Val:  ` "derby"`,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											{
+												Type: "ObjectConsItem",
+												Children: []TestTreeNode{
+													{
+														Type: "ObjectConsKey",
+														Children: []TestTreeNode{
+															{
+																Type: "Tokens",
+																Val:  " // a fancy hat\n",
+															},
+															{
+																Type: "Expression",
+																Children: []TestTreeNode{
+																	{
+																		Type: "Tokens",
+																		Val:  "          (",
+																	},
+																	{
+																		Type: "Traversal",
+																		Children: []TestTreeNode{
+																			{
+																				Type:     "TraverseName",
+																				Children: []TestTreeNode{{Type: "identifier", Val: "cat"}},
+																			},
+																		},
+																	},
+																	{
+																		Type: "Tokens",
+																		Val:  ")",
+																	},
+																},
+															},
+														},
+													},
+													{
+														Type: "ObjectConsValue",
+														Children: []TestTreeNode{
+															{
+																Type: "Tokens",
+																Val:  " =",
+															},
+															{
+																Type: "Expression",
+																Children: []TestTreeNode{
+																	{
+																		Type: "Tokens",
+																		Val:  ` "calico"`,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											{
+												Type: "Tokens",
+												Val:  "\n   }",
+											},
+										},
+									},
+								},
+							},
+							{
+								Type: "comments",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

Builds an AST for object-construct expressions such as:
```hcl
a = {
    hat = "derby", (cat) = "calico" }
```

Given an `hclwrite.Expression`, an application can read an object value as:
```go
object := expr.AsObjectConsExpr()
value := object.ValueFor("hat")

tokens := value.Expr().BuildTokens(nil)
```

Retrieval is based on matching a Go string to an HCL identifier. As an implementation choice, there is no way to retrieve the value for the variable expression `(cat)` at the time of this pull request.

https://github.com/hashicorp/hcl/pull/811 is a speculative pull request that builds on this one and introduces the capability to rewrite objects.

## Related Issue

https://github.com/hashicorp/hcl/issues/695 and design notes from Martin in https://github.com/hashicorp/hcl/issues/695#issuecomment-2569776621.

## How Has This Been Tested?

`hclwrite/parser_test.go`