### PR TITLE
fix(hclsyntax): implement recursion depth limit inside parseBinaryOps to prevent stack overflow

### DIFF
--- a/hclsyntax/parser.go
+++ b/hclsyntax/parser.go
@@ -22,6 +22,7 @@ type parser struct {
 	// in recovery mode, assuming that the recovery heuristics have failed
 	// in this case and left the peeker in a wrong place.
 	recovery bool
+	recursionDepth int
 }
 
 func (p *parser) ParseBody(end TokenType) (*Body, hcl.Diagnostics) {
@@ -548,11 +549,23 @@ func (p *parser) parseTernaryConditional() (Expression, hcl.Diagnostics) {
 		SrcRange: hcl.RangeBetween(startRange, falseExpr.Range()),
 	}, diags
 }
-
+const maxHCLParsingDepth = 1000
 // parseBinaryOps calls itself recursively to work through all of the
 // operator precedence groups, and then eventually calls parseExpressionTerm
 // for each operand.
 func (p *parser) parseBinaryOps(ops []map[TokenType]*Operation) (Expression, hcl.Diagnostics) {
+	p.recursionDepth++
+	if p.recursionDepth > maxHCLParsingDepth {
+		var diags hcl.Diagnostics
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Expression nesting limit exceeded",
+			Detail:   "The expression contains too many nested layers of parentheses or operations, causing a parser safety cutoff.",
+		})
+		p.recursionDepth--
+		return &LiteralValueExpr{Val: cty.DynamicVal, SrcRange: p.Peek().Range}, diags
+	}
+	defer func() { p.recursionDepth-- }()
 	if len(ops) == 0 {
 		// We've run out of operators, so now we'll just try to parse a term.
 		return p.parseExpressionWithTraversals()

--- a/hclsyntax/parser_test.go
+++ b/hclsyntax/parser_test.go
@@ -4,6 +4,7 @@
 package hclsyntax
 
 import (
+	"strings"
 	"fmt"
 	"sync"
 	"testing"
@@ -4327,5 +4328,17 @@ func TestParseConfigDiagnostics(t *testing.T) {
 				t.Errorf("wrong diagnostics\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestParseExpression_nestedParenthesesRecursionGuard(t *testing.T) {
+	src := []byte(strings.Repeat("(", 1001) + "1" + strings.Repeat(")", 1001))
+	_, diags := ParseExpression(src, "test.hcl", hcl.InitialPos)
+	if !diags.HasErrors() {
+		t.Fatal("expected a parser nesting depth error, but got no errors")
+	}
+	expectedSummary := "Expression nesting limit exceeded"
+	if diags[0].Summary != expectedSummary {
+		t.Errorf("expected error summary %q, got %q", expectedSummary, diags[0].Summary)
 	}
 }


### PR DESCRIPTION
### Summary
This PR introduces a hard recursion depth threshold of `1000` loops inside `parseBinaryOps` to safely intercept deeply nested expressions (such as thousands of sequential parenthetical configurations) before they exhaust the standard Go goroutine stack runtime allocation. 

### Root Cause & Resolution
- **The Bug:** When parsing configurations with excessive nested layers like `(((((...)))))`, the recursive descent structure of `parseBinaryOps` continually allocates frames on the stack. This eventually results in a non-recoverable, fatal stack overflow panic (`runtime: goroutine stack exceeds 1000000000-byte limit`).
- **The Fix:** Added a tracking field `recursionDepth` to the internal package `parser` struct. Entering `parseBinaryOps` increments this counter, checks against a strict max ceiling (`1000`), and returns a structured `hcl.Diagnostic` payload gracefully if crossed instead of throwing an unhandled panic. It clears down via a deferred frame decrement step.
- **Testing:** Implemented a target validation regression block `TestParseExpression_nestedParenthesesRecursionGuard` inside `parser_test.go` to assert defensive validation engine boundaries.

Fixes #809