### PR TITLE
ext/typeexpr: render optional attributes in TypeString

### DIFF
--- a/ext/typeexpr/public.go
+++ b/ext/typeexpr/public.go
@@ -114,7 +114,17 @@ func TypeString(ty cty.Type) string {
 				buf.WriteString(name)
 			}
 			buf.WriteByte('=')
-			buf.WriteString(TypeString(aty))
+			if ty.AttributeOptional(name) {
+				// Optional attributes are rendered with the optional(...)
+				// modifier so that the result round-trips through
+				// TypeConstraint. The default value, if any, is tracked
+				// separately from the type and so cannot be included here.
+				buf.WriteString("optional(")
+				buf.WriteString(TypeString(aty))
+				buf.WriteByte(')')
+			} else {
+				buf.WriteString(TypeString(aty))
+			}
 			first = false
 		}
 		buf.WriteString("})")

--- a/ext/typeexpr/type_string_test.go
+++ b/ext/typeexpr/type_string_test.go
@@ -55,6 +55,14 @@ func TestTypeString(t *testing.T) {
 			"object({bar=string,foo=bool})",
 		},
 		{
+			cty.ObjectWithOptionalAttrs(map[string]cty.Type{"foo": cty.Bool}, []string{"foo"}),
+			"object({foo=optional(bool)})",
+		},
+		{
+			cty.ObjectWithOptionalAttrs(map[string]cty.Type{"foo": cty.Bool, "bar": cty.String}, []string{"bar"}),
+			"object({bar=optional(string),foo=bool})",
+		},
+		{
 			cty.EmptyTuple,
 			"tuple([])",
 		},


### PR DESCRIPTION
## Description

`TypeString` renders object types but drops the `optional(...)` modifier, so its output does not round-trip back through `TypeConstraint`.

The doc comment says the result is rendered "as it would be expected to appear in the HCL native syntax" and that it "produces reasonable results only for types like what would be produced by the `Type` and `TypeConstraint` functions." `TypeConstraint` does produce object types with optional attributes, but `TypeString` emits them as plain required attributes:

```go
ty := cty.ObjectWithOptionalAttrs(map[string]cty.Type{"foo": cty.Bool}, []string{"foo"})
typeexpr.TypeString(ty) // "object({foo=bool})"  -- optional dropped
```

Re-parsing that string gives `AttributeOptional("foo") == false`, so an optional attribute silently becomes required.

`optional(...)` parsing was added in 47464b2 but `TypeString` was never updated to render it. This fixes that by wrapping optional attributes in `optional(...)`. Default values are tracked in the separate `Defaults` struct rather than in `cty.Type`, so they aren't available here; `optional(type)` is valid native syntax and restores the round-trip.

## Related Issue

None.

## How Has This Been Tested?

Added two cases to `TestTypeString`. They fail before the change:

```
got:  object({foo=bool})
want: object({foo=optional(bool)})
```

and pass after it. `go test ./ext/typeexpr/...`, `go vet ./ext/typeexpr/...`, and `gofmt -l` are clean. Confirmed the corrected output re-parses: `object({a=optional(string)})` yields `AttributeOptional("a") == true`.

Happy to add a CHANGELOG entry if you'd like one.
