### PR TITLE
docs(hclparse): point package comment at hclsimple

### DIFF
--- a/hclparse/parser.go
+++ b/hclparse/parser.go
@@ -4,15 +4,10 @@
 // Package hclparse has the main API entry point for parsing both HCL native
 // syntax and HCL JSON.
 //
-// The main HCL package also includes SimpleParse and SimpleParseFile which
-// can be a simpler interface for the common case where an application just
-// needs to parse a single file. The gohcl package simplifies that further
-// in its SimpleDecode function, which combines hcl.SimpleParse with decoding
-// into Go struct values
-//
-// Package hclparse, then, is useful for applications that require more fine
-// control over parsing or which need to load many separate files and keep
-// track of them for possible error reporting or other analysis.
+// For the common case of loading configuration into a Go struct in one step,
+// see package hclsimple instead. Package hclparse is useful when an application
+// needs finer control over parsing or must load many separate files and keep
+// track of them for diagnostics or other analysis.
 package hclparse
 
 import (


### PR DESCRIPTION
## Summary
The `hclparse` package comment still documents `hcl.SimpleParse`, `hcl.SimpleParseFile`, and `gohcl.SimpleDecode`, which do not exist in this module (pre-v2 leftover).

Update the comment to point at `hclsimple` for the one-step decode path, matching the root package docs and @apparentlymart's note on #793.

## Test plan
- [x] `go test ./hclparse/ ./hclsimple/`
- [x] Comment-only change; no API behavior change

Fixes #793
