### PR TITLE
docs(hclparse): point package comment at hclsimple helpers

### DIFF
--- a/hclparse/parser.go
+++ b/hclparse/parser.go
@@ -4,11 +4,9 @@
 // Package hclparse has the main API entry point for parsing both HCL native
 // syntax and HCL JSON.
 //
-// The main HCL package also includes SimpleParse and SimpleParseFile which
-// can be a simpler interface for the common case where an application just
-// needs to parse a single file. The gohcl package simplifies that further
-// in its SimpleDecode function, which combines hcl.SimpleParse with decoding
-// into Go struct values
+// The hclsimple package provides a simpler interface for the common case
+// where an application just needs to parse a single file and decode it into
+// Go struct values, via hclsimple.Decode and hclsimple.DecodeFile.
 //
 // Package hclparse, then, is useful for applications that require more fine
 // control over parsing or which need to load many separate files and keep


### PR DESCRIPTION
## Summary
- Update the `hclparse` package comment so it no longer references `SimpleParse`, `SimpleParseFile`, or `gohcl.SimpleDecode`, which are not part of HCL v2.
- Point readers at `hclsimple.Decode` and `hclsimple.DecodeFile` for the common single-file decode path, matching maintainer guidance on #793.

Fixes #793

## Test plan
- [x] Confirmed `hclsimple.Decode` / `DecodeFile` are the public helpers described
- [x] `go test ./hclparse/` (no test files; package builds)