### PR TITLE
fix: limit expression nesting depth to prevent stack overflow

### DIFF
--- a/hclsyntax/parser.go
+++ b/hclsyntax/parser.go
@@ -22,7 +22,24 @@ type parser struct {
 	// in recovery mode, assuming that the recovery heuristics have failed
 	// in this case and left the peeker in a wrong place.
 	recovery bool
+
+	// exprDepth tracks how many nested calls to ParseExpression are
+	// currently on the Go call stack, so that deeply-nested expressions
+	// (parentheses, arrays, objects, function calls, etc. are all
+	// mutually recursive through ParseExpression) can be rejected with a
+	// normal diagnostic instead of exhausting the goroutine stack, which
+	// would abort the whole process with an unrecoverable fatal error.
+	exprDepth int
 }
+
+// maxExpressionDepth is the maximum nesting depth ParseExpression will
+// recurse to before giving up and returning an error. It's set far higher
+// than any reasonable hand-written expression would ever reach, while
+// still comfortably avoiding a stack overflow: each level of nesting here
+// corresponds to several stack frames (ParseExpression itself calls through
+// parseTernaryConditional, a chain of parseBinaryOps precedence levels, and
+// parseExpressionTerm before it can recurse again).
+const maxExpressionDepth = 200
 
 func (p *parser) ParseBody(end TokenType) (*Body, hcl.Diagnostics) {
 	attrs := Attributes{}
@@ -485,6 +502,31 @@ Token:
 }
 
 func (p *parser) ParseExpression() (Expression, hcl.Diagnostics) {
+	p.exprDepth++
+	defer func() { p.exprDepth-- }()
+
+	if p.exprDepth > maxExpressionDepth {
+		// Expressions recurse back into ParseExpression at every level of
+		// nesting (parentheses, arrays, objects, function call arguments,
+		// etc.), so without this check a sufficiently deeply-nested
+		// expression would exhaust the goroutine stack and crash the whole
+		// process with an unrecoverable fatal error rather than a normal,
+		// recoverable diagnostic.
+		start := p.NextRange()
+		p.setRecovery()
+		return &LiteralValueExpr{
+				Val:      cty.DynamicVal,
+				SrcRange: start,
+			}, hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Expression is too deeply nested",
+					Detail:   fmt.Sprintf("This expression is nested more than %d levels deep, which is not supported.", maxExpressionDepth),
+					Subject:  &start,
+				},
+			}
+	}
+
 	return p.parseTernaryConditional()
 }
 

--- a/hclsyntax/parser_test.go
+++ b/hclsyntax/parser_test.go
@@ -5,6 +5,7 @@ package hclsyntax
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -4325,6 +4326,49 @@ func TestParseConfigDiagnostics(t *testing.T) {
 
 			if diff := cmp.Diff(test.want, diags); diff != "" {
 				t.Errorf("wrong diagnostics\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestParseExpression_deeplyNested is a regression test for a stack
+// overflow (an unrecoverable Go fatal error, not a panic) that used to
+// occur when parsing an expression with many levels of nesting, since
+// ParseExpression recurses back into itself with no depth limit for every
+// level of parentheses, array/object construction, or function call
+// arguments.
+func TestParseExpression_deeplyNested(t *testing.T) {
+	tests := []struct {
+		name  string
+		open  string
+		close string
+	}{
+		{"parentheses", "(", ")"},
+		{"arrays", "[", "]"},
+		{"function calls", "foo(", ")"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const depth = maxExpressionDepth + 100
+			src := strings.Repeat(test.open, depth) + "1" + strings.Repeat(test.close, depth)
+
+			expr, diags := ParseExpression([]byte(src), "test.hcl", hcl.InitialPos)
+
+			if expr == nil {
+				t.Fatal("ParseExpression returned a nil expression")
+			}
+			if !diags.HasErrors() {
+				t.Fatal("expected a 'too deeply nested' diagnostic, but ParseExpression succeeded")
+			}
+			found := false
+			for _, diag := range diags {
+				if diag.Summary == "Expression is too deeply nested" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("expected a 'too deeply nested' diagnostic, got: %s", diags)
 			}
 		})
 	}


### PR DESCRIPTION
## What's the bug

A deeply-nested `hclsyntax` expression (many thousand levels of parentheses, as in the linked issue, but the same applies to nested arrays/objects/function calls) crashes the whole process with `fatal error: stack overflow`. This is a Go **fatal error**, not a `panic` - `recover()` cannot catch it, so any program parsing untrusted or accidentally-malformed HCL (e.g. `terraform apply` on a generated config) has no way to survive it.

## Root cause

`parser.ParseExpression` recurses back into itself for every level of expression nesting - parentheses, array/object construction, and function call arguments are all mutually recursive through it (`ParseExpression` → `parseTernaryConditional` → `parseBinaryOps` (chain) → `parseExpressionWithTraversals` → `parseExpressionTerm` → back to `ParseExpression` for whatever's inside the `(`/`[`/`{`/call) - with no depth limit anywhere in that cycle.

## The fix

Added an `exprDepth` counter to `parser`, incremented for the duration of each `ParseExpression` call (via `defer`). Once it exceeds `maxExpressionDepth` (200 - far beyond any hand-written expression, while leaving a comfortable margin against overflow, since each nesting level here costs several stack frames), `ParseExpression` returns a normal diagnostic instead of recursing further, using the same placeholder-expression pattern (`LiteralValueExpr{Val: cty.DynamicVal}`) already used elsewhere in this file for other parse errors - so the AST stays structurally sound and callers get an ordinary error instead of a crash.

Scope note: `hcl/json`'s parser (`parseValue`/`parseObject`/`parseArray`) has the same class of unbounded mutual recursion, but I left it out of this PR to keep the fix scoped to the reported issue - it uses a different internal structure (a bare `peeker`, not this package's `parser` type) so a depth limit there would need its own, separate change. Happy to follow up with that if useful.

## Testing

- Added `TestParseExpression_deeplyNested` (`hclsyntax/parser_test.go`), covering all three recursive nesting forms that reach `ParseExpression` - parentheses, arrays, and function call arguments - each nested to `maxExpressionDepth + 100` levels, asserting a `"Expression is too deeply nested"` diagnostic is returned (not a crash, and not silent success).
- Verified by reverting just the `parser.go` change (keeping the test, with `maxExpressionDepth` temporarily hardcoded to compile): at 300 levels of nesting, the unfixed parser accepts the input with **no error at all** for all three forms - confirming there was no limit before this change - while the fixed parser correctly rejects it past 200.
- Ran the full `go test ./...` suite. The only failures (`specsuite/TestSpec`'s `expressions/heredoc`, `structure/attributes/unexpected`, `structure/blocks/single_oneline_invalid` subtests) are pre-existing and unrelated - confirmed identical on an unmodified checkout of `main`, and none of them involve expression nesting.

Fixes #809