### PR TITLE
hclwrite: introduce `Body.RemoveNewlineBeforeBlock`

### DIFF
--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -137,6 +137,52 @@ func (b *Body) FirstMatchingBlock(typeName string, labels []string) *Block {
 	return nil
 }
 
+// RemoveNewlineBeforeBlock makes a best effort to remove one newline of
+// vertical separation before a block.
+//
+// It will not remove the trailing newline of a preceding structural element,
+// such as an attribute or a block.
+
+// The pair of RemoveNewlineBeforeBlock + RemoveBlock is an "undo" move for the
+// pair of AppendNewline + AppendNewBlock.
+func (b *Body) RemoveNewlineBeforeBlock(block *Block) bool {
+	for n := range b.items {
+		if n.content != block {
+			continue
+		}
+		if n.before == nil {
+			return false
+		}
+
+		// Detect "unstructured token"-only nodes. Structured content, such as
+		// an attribute, includes its trailing newline, so we will not remove
+		// that.
+		if tokens, ok := n.before.content.(Tokens); ok {
+			count := len(tokens)
+			switch count {
+			case 0:
+				break
+
+			case 1:
+				// It seems unlikely for this to be anything other than a
+				// newline. And yet, we verify.
+				if tokens[0].Type == hclsyntax.TokenNewline {
+					b.items.Remove(n.before)
+					n.before.Detach()
+					return true
+				}
+
+			default:
+				// It seems unlikely for this case to occur. Until we can
+				// characterize it with an example, we will pass.
+
+				break
+			}
+		}
+	}
+	return false
+}
+
 // RemoveBlock removes the given block from the body, if it's in that body.
 // If it isn't present, this is a no-op.
 //
@@ -247,7 +293,7 @@ func (b *Body) AppendNewBlock(typeName string, labels []string) *Block {
 	return block
 }
 
-// AppendNewline appends a newline token to th end of the receiving body,
+// AppendNewline appends a newline token to the end of the receiving body,
 // which generally serves as a separator between different sets of body
 // contents.
 func (b *Body) AppendNewline() {

--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -173,9 +173,13 @@ func (b *Body) RemoveNewlineBeforeBlock(block *Block) bool {
 				}
 
 			default:
-				newTokens := tokens[:count-1]
-				n.before.ReplaceWith(newTokens)
-				return true
+				// It seems unlikely for this to be anything other than a
+				// newline. And yet, we verify.
+				if tokens[count-1].Type == hclsyntax.TokenNewline {
+					newTokens := tokens[:count-1]
+					n.before.ReplaceWith(newTokens)
+					return true
+				}
 			}
 		}
 	}

--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -173,10 +173,9 @@ func (b *Body) RemoveNewlineBeforeBlock(block *Block) bool {
 				}
 
 			default:
-				// It seems unlikely for this case to occur. Until we can
-				// characterize it with an example, we will pass.
-
-				break
+				newTokens := tokens[:count-1]
+				n.before.ReplaceWith(newTokens)
+				return true
 			}
 		}
 	}

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -2161,8 +2161,6 @@ cat {
 		block := f.Body().FirstMatchingBlock(test.blockType, nil)
 		removed := f.Body().RemoveNewlineBeforeBlock(block)
 
-		t.Log(makeTestTree(f.body))
-
 		if removed != test.wantReturnValue {
 			t.Errorf("expected RemoveNewlineBeforeBlock to return %v; got %v", test.wantReturnValue, removed)
 		}

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -1857,6 +1857,325 @@ bar {}
 
 }
 
+func TestBodyRemoveNewlineBeforeBlock(t *testing.T) {
+	tests := []struct {
+		src             string
+		blockType       string
+		wantReturnValue bool
+		want            Tokens
+	}{
+		{
+			src: `
+a = 1
+
+cat {
+}
+`,
+			blockType:       `cat`,
+			wantReturnValue: true,
+			want: Tokens{
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`a`),
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte(`=`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNumberLit,
+					Bytes:        []byte(`1`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				// One newline removed.
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`cat`),
+				},
+				{
+					Type:         hclsyntax.TokenOBrace,
+					Bytes:        []byte(`{`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenCBrace,
+					Bytes: []byte(`}`),
+				},
+				{
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
+				},
+			},
+		},
+		{
+			src: `
+a = 1
+
+
+cat {
+}
+`,
+			blockType:       `cat`,
+			wantReturnValue: true,
+			want: Tokens{
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`a`),
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte(`=`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNumberLit,
+					Bytes:        []byte(`1`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				// One newline removed.
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`cat`),
+				},
+				{
+					Type:         hclsyntax.TokenOBrace,
+					Bytes:        []byte(`{`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenCBrace,
+					Bytes: []byte(`}`),
+				},
+				{
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
+				},
+			},
+		},
+		{
+			src: `
+a = 1
+
+// bat
+// hat
+cat {
+}
+`,
+			blockType:       `cat`,
+			wantReturnValue: true,
+			want: Tokens{
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`a`),
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte(`=`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNumberLit,
+					Bytes:        []byte(`1`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				// One newline removed.
+				{
+					Type:  hclsyntax.TokenComment,
+					Bytes: []byte(`// bat` + "\n"),
+				},
+				{
+					Type:  hclsyntax.TokenComment,
+					Bytes: []byte(`// hat` + "\n"),
+				},
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`cat`),
+				},
+				{
+					Type:         hclsyntax.TokenOBrace,
+					Bytes:        []byte(`{`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenCBrace,
+					Bytes: []byte(`}`),
+				},
+				{
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
+				},
+			},
+		},
+		{
+			src: `
+a = 1
+
+# bat
+# hat
+cat {
+}
+`,
+			blockType:       `cat`,
+			wantReturnValue: true,
+			want: Tokens{
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`a`),
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte(`=`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNumberLit,
+					Bytes:        []byte(`1`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				// One newline removed.
+				{
+					Type:  hclsyntax.TokenComment,
+					Bytes: []byte(`# bat` + "\n"),
+				},
+				{
+					Type:  hclsyntax.TokenComment,
+					Bytes: []byte(`# hat` + "\n"),
+				},
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`cat`),
+				},
+				{
+					Type:         hclsyntax.TokenOBrace,
+					Bytes:        []byte(`{`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenCBrace,
+					Bytes: []byte(`}`),
+				},
+				{
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
+				},
+			},
+		},
+		{
+			src: `
+a = 1
+cat {
+}
+`,
+			blockType:       `cat`,
+			wantReturnValue: false,
+			want: Tokens{
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`a`),
+				},
+				{
+					Type:         hclsyntax.TokenEqual,
+					Bytes:        []byte(`=`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:         hclsyntax.TokenNumberLit,
+					Bytes:        []byte(`1`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenIdent,
+					Bytes: []byte(`cat`),
+				},
+				{
+					Type:         hclsyntax.TokenOBrace,
+					Bytes:        []byte(`{`),
+					SpacesBefore: 1,
+				},
+				{
+					Type:  hclsyntax.TokenNewline,
+					Bytes: []byte("\n"),
+				},
+				{
+					Type:  hclsyntax.TokenCBrace,
+					Bytes: []byte(`}`),
+				},
+				{
+					Type:  hclsyntax.TokenEOF,
+					Bytes: []byte{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		f, diags := ParseConfig([]byte(strings.TrimSpace(test.src)), "", hcl.InitialPos)
+		if diags.HasErrors() {
+			for _, diag := range diags {
+				t.Logf("- %s", diag.Error())
+			}
+			t.Fatalf("unexpected diagnostics")
+		}
+
+		block := f.Body().FirstMatchingBlock(test.blockType, nil)
+		removed := f.Body().RemoveNewlineBeforeBlock(block)
+
+		t.Log(makeTestTree(f.body))
+
+		if removed != test.wantReturnValue {
+			t.Errorf("expected RemoveNewlineBeforeBlock to return %v; got %v", test.wantReturnValue, removed)
+		}
+
+		got := f.BuildTokens(nil)
+		format(got)
+		if !reflect.DeepEqual(got, test.want) {
+			diff := cmp.Diff(test.want, got)
+			t.Errorf("wrong result\ndiff:\n%s", diff)
+		}
+	}
+}
+
 // testFn is a convenience function that wraps a function call that returns a
 // value and diagnostics.
 //


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

`RemoveNewlineBeforeBlock` makes a best effort to remove one newline of vertical separation before a block.

It will not remove the trailing newline of a preceding structural element, such as an attribute or a block.

The pair of `RemoveNewlineBeforeBlock` + `RemoveBlock` is an "undo" move for the pair of `AppendNewline` + `AppendNewBlock`.

## How Has This Been Tested?

Tests enclosed.