### PR TITLE
hclwrite: emit multi-line blocks when a nested block is present

### DIFF
--- a/hclwrite/ast.go
+++ b/hclwrite/ast.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite
@@ -34,11 +34,12 @@ func (f *File) Body() *Body {
 
 // WriteTo writes the tokens underlying the receiving file to the given writer.
 //
-// The tokens first have a simple formatting pass applied that adjusts only
-// the spaces between them.
+// The tokens first have a simple formatting pass applied that adjusts
+// whitespace, including inserting newlines so a nested block is not left
+// on the same line as its parent opening brace.
 func (f *File) WriteTo(wr io.Writer) (int64, error) {
 	tokens := f.children.BuildTokens(nil)
-	format(tokens)
+	tokens = format(tokens)
 	return tokens.WriteTo(wr)
 }
 

--- a/hclwrite/ast_block_test.go
+++ b/hclwrite/ast_block_test.go
@@ -189,7 +189,7 @@ func TestBlockSetType_buildTokens(t *testing.T) {
 			b := f.Body().FirstMatchingBlock(test.oldTypeName, test.labels)
 			b.SetType(test.newTypeName)
 			got := f.BuildTokens(nil)
-			format(got)
+			got = format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
@@ -500,7 +500,7 @@ func TestBlockSetLabels(t *testing.T) {
 			b := f.Body().FirstMatchingBlock(test.typeName, test.oldLabels)
 			b.SetLabels(test.newLabels)
 			got := f.BuildTokens(nil)
-			format(got)
+			got = format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -535,7 +535,7 @@ func TestBodySetAttributeValue(t *testing.T) {
 
 			f.Body().SetAttributeValue(test.name, test.val)
 			got := f.BuildTokens(nil)
-			format(got)
+			got = format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
@@ -761,7 +761,7 @@ func TestBodySetAttributeTraversal(t *testing.T) {
 
 			f.Body().SetAttributeTraversal(test.name, traversal)
 			got := f.BuildTokens(nil)
-			format(got)
+			got = format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
@@ -963,7 +963,7 @@ func TestBodySetAttributeRaw(t *testing.T) {
 
 			f.Body().SetAttributeRaw(test.name, test.tokens)
 			got := f.BuildTokens(nil)
-			format(got)
+			got = format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
@@ -1074,7 +1074,7 @@ func TestBodySetAttributeValueInBlock(t *testing.T) {
 			b := f.Body().FirstMatchingBlock(test.typeName, test.labels)
 			b.Body().SetAttributeValue(test.attr, test.val)
 			tokens := f.BuildTokens(nil)
-			format(tokens)
+			tokens = format(tokens)
 			got := string(tokens.Bytes())
 			if got != test.want {
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\n", got, test.want)
@@ -1129,7 +1129,7 @@ func TestBodySetAttributeValueInNestedBlock(t *testing.T) {
 			child := parent.Body().FirstMatchingBlock(test.childTypeName, []string{})
 			child.Body().SetAttributeValue(test.attr, test.val)
 			tokens := f.BuildTokens(nil)
-			format(tokens)
+			tokens = format(tokens)
 			got := string(tokens.Bytes())
 			if got != test.want {
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\n", got, test.want)
@@ -1242,7 +1242,7 @@ func TestBodyRemoveAttribute(t *testing.T) {
 
 			f.Body().RemoveAttribute(test.name)
 			got := f.BuildTokens(nil)
-			format(got)
+			got = format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
@@ -1403,7 +1403,7 @@ func TestBodyRenameAttribute(t *testing.T) {
 			success := f.Body().RenameAttribute(test.oldName, test.newName)
 
 			got := f.BuildTokens(nil)
-			format(got)
+			got = format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
@@ -1649,12 +1649,41 @@ func TestBodyAppendBlock(t *testing.T) {
 
 			f.Body().AppendNewBlock(test.blockType, test.labels)
 			got := f.BuildTokens(nil)
-			format(got)
+			got = format(got)
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
 			}
 		})
+	}
+}
+
+func TestBodyAppendNewBlockToSingleLineParent(t *testing.T) {
+	// github.com/hashicorp/hcl/issues/687
+	// Appending a nested block into a single-line empty parent used to emit
+	// `atlas { cloud { ... } }`, which the parser rejects. Format must emit
+	// multi-line form so the result round-trips.
+	f, diags := ParseConfig([]byte("atlas {}"), "atlas.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("initial parse failed: %s", diags)
+	}
+
+	parent := f.Body().FirstMatchingBlock("atlas", nil)
+	if parent == nil {
+		t.Fatal("missing atlas block")
+	}
+	parent.Body().AppendNewBlock("cloud", nil)
+
+	out := Format(f.Bytes())
+	got := string(out)
+	want := "atlas {\n  cloud {\n  }\n}"
+	if got != want {
+		t.Errorf("wrong formatted result\ngot:\n%s\nwant:\n%s", got, want)
+	}
+
+	_, diags = ParseConfig(out, "atlas.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Errorf("formatted output did not reparse: %s", diags)
 	}
 }
 
@@ -1784,7 +1813,7 @@ bar {}
 			SpacesBefore: 0,
 		},
 	}
-	format(got)
+	got = format(got)
 	if !reflect.DeepEqual(got, want) {
 		diff := cmp.Diff(want, got)
 		t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(want), diff)
@@ -1849,7 +1878,7 @@ bar {}
 			SpacesBefore: 0,
 		},
 	}
-	format(got)
+	got = format(got)
 	if !reflect.DeepEqual(got, want) {
 		diff := cmp.Diff(want, got)
 		t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(want), diff)

--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite
@@ -7,27 +7,157 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
-// format rewrites tokens within the given sequence, in-place, to adjust the
-// whitespace around their content to achieve canonical formatting.
-func format(tokens Tokens) {
+// format rewrites tokens within the given sequence to adjust the whitespace
+// around their content to achieve canonical formatting.
+//
+// The SpacesBefore mutations happen in-place on the given tokens. format may
+// also insert newline tokens so that a block containing a nested block is
+// emitted in multi-line form; a single-line block may contain only one
+// argument, so a nested block cannot share a line with its parent's opening
+// brace. Callers must use the returned slice, which is the original slice
+// when no newlines were inserted.
+func format(tokens Tokens) Tokens {
 	// Formatting is a multi-pass process. More details on the passes below,
 	// but this is the overview:
+	// - insert newlines to force multi-line form when a block contains a
+	//   nested block on the same line as its opening brace
 	// - adjust the leading space on each line to create appropriate
 	//   indentation
 	// - adjust spaces between tokens in a single cell using a set of rules
 	// - adjust the leading space in the "assign" and "comment" cells on each
 	//   line to vertically align with neighboring lines.
-	// All of these steps operate in-place on the given tokens, so a caller
-	// may collect a flat sequence of all of the tokens underlying an AST
-	// and pass it here and we will then indirectly modify the AST itself.
-	// Formatting must change only whitespace. Specifically, that means
-	// changing the SpacesBefore attribute on a token while leaving the
-	// other token attributes unchanged.
+	// All of these steps operate in-place on the given tokens (aside from
+	// possible newline insertion), so a caller may collect a flat sequence
+	// of all of the tokens underlying an AST and pass it here and we will
+	// then indirectly modify the AST itself.
 
+	tokens = formatExpandSingleLineNestedBlocks(tokens)
 	lines := linesForFormat(tokens)
 	formatIndent(lines)
 	formatSpaces(lines)
 	formatCells(lines)
+	return tokens
+}
+
+// formatExpandSingleLineNestedBlocks inserts newlines so that any block which
+// contains a nested block on the same line as its opening brace is rewritten
+// into multi-line form. The native parser rejects nested blocks in single-line
+// block syntax ("A single-line block definition can contain only a single
+// argument").
+func formatExpandSingleLineNestedBlocks(tokens Tokens) Tokens {
+	if len(tokens) == 0 {
+		return tokens
+	}
+
+	insertBefore := map[int]struct{}{}
+
+	for i, tok := range tokens {
+		if tok.Type != hclsyntax.TokenOBrace || !isBlockOpenBrace(tokens, i) {
+			continue
+		}
+		closeIdx := matchingCloseBrace(tokens, i)
+		if closeIdx < 0 {
+			continue
+		}
+
+		var nestedTypeIdxs []int
+		for j := i + 1; j < closeIdx; j++ {
+			if tokenIsNewline(tokens[j]) {
+				// Already multi-line; leave the interior of this block alone.
+				break
+			}
+			if tokens[j].Type == hclsyntax.TokenOBrace && isBlockOpenBrace(tokens, j) {
+				if typeIdx := nestedBlockTypeIndex(tokens, j); typeIdx >= 0 {
+					nestedTypeIdxs = append(nestedTypeIdxs, typeIdx)
+				}
+			}
+		}
+		if len(nestedTypeIdxs) == 0 {
+			continue
+		}
+
+		if i+1 < len(tokens) && !tokenIsNewline(tokens[i+1]) {
+			insertBefore[i+1] = struct{}{}
+		}
+		for _, typeIdx := range nestedTypeIdxs {
+			if typeIdx > 0 && !tokenIsNewline(tokens[typeIdx-1]) {
+				insertBefore[typeIdx] = struct{}{}
+			}
+		}
+		if closeIdx > 0 && !tokenIsNewline(tokens[closeIdx-1]) {
+			insertBefore[closeIdx] = struct{}{}
+		}
+	}
+
+	if len(insertBefore) == 0 {
+		return tokens
+	}
+
+	out := make(Tokens, 0, len(tokens)+len(insertBefore))
+	for i, tok := range tokens {
+		if _, ok := insertBefore[i]; ok {
+			out = append(out, &Token{
+				Type:  hclsyntax.TokenNewline,
+				Bytes: []byte{'\n'},
+			})
+		}
+		out = append(out, tok)
+	}
+	return out
+}
+
+// isBlockOpenBrace reports whether the brace at openIdx is the opening brace
+// of a block (as opposed to an object constructor). Block braces are preceded
+// by a type name or a block label.
+func isBlockOpenBrace(tokens Tokens, openIdx int) bool {
+	for i := openIdx - 1; i >= 0; i-- {
+		tok := tokens[i]
+		if tokenIsNewline(tok) || tok.Type == hclsyntax.TokenComment {
+			continue
+		}
+		switch tok.Type {
+		case hclsyntax.TokenIdent, hclsyntax.TokenCQuote:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func matchingCloseBrace(tokens Tokens, openIdx int) int {
+	depth := 0
+	for i := openIdx; i < len(tokens); i++ {
+		switch tokens[i].Type {
+		case hclsyntax.TokenOBrace:
+			depth++
+		case hclsyntax.TokenCBrace:
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// nestedBlockTypeIndex returns the index of the type-name token of the block
+// whose opening brace is at nestedOpen, walking back over any labels.
+func nestedBlockTypeIndex(tokens Tokens, nestedOpen int) int {
+	typeIdx := -1
+	for i := nestedOpen - 1; i >= 0; i-- {
+		switch tokens[i].Type {
+		case hclsyntax.TokenIdent:
+			typeIdx = i
+		case hclsyntax.TokenCQuote, hclsyntax.TokenQuotedLit, hclsyntax.TokenOQuote:
+			// quoted label; keep walking back to the type name
+		case hclsyntax.TokenComment:
+			// ignore
+		default:
+			return typeIdx
+		}
+	}
+	return typeIdx
 }
 
 func formatIndent(lines []formatLine) {

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite
@@ -633,12 +633,36 @@ module "x" {
 			`attr = provider::+example()`,
 			`attr = provider:: + example()`,
 		},
+		{
+			// Nested block inside a single-line parent must be rewritten as
+			// multi-line; the parser rejects nested blocks in single-line form.
+			`atlas { cloud {
+}
+}`,
+			`atlas {
+  cloud {
+  }
+}`,
+		},
+		{
+			`atlas { cloud {} }`,
+			`atlas {
+  cloud {}
+}`,
+		},
+		{
+			`atlas { foo = 1 cloud {} }`,
+			`atlas {
+  foo = 1
+  cloud {}
+}`,
+		},
 	}
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
 			tokens := lexConfig([]byte(test.input))
-			format(tokens)
+			tokens = format(tokens)
 			t.Logf("tokens %s\n", spew.Sdump(tokens))
 			got := string(tokens.Bytes())
 

--- a/hclwrite/generate.go
+++ b/hclwrite/generate.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite
@@ -25,7 +25,7 @@ import (
 // no unknown values are present before calling TokensForValue.
 func TokensForValue(val cty.Value) Tokens {
 	toks := appendTokensForValue(val, nil)
-	format(toks) // fiddle with the SpacesBefore field to get canonical spacing
+	toks = format(toks) // fiddle with the SpacesBefore field to get canonical spacing
 	return toks
 }
 
@@ -38,7 +38,7 @@ func TokensForValue(val cty.Value) Tokens {
 // represented expression.
 func TokensForTraversal(traversal hcl.Traversal) Tokens {
 	toks := appendTokensForTraversal(traversal, nil)
-	format(toks) // fiddle with the SpacesBefore field to get canonical spacing
+	toks = format(toks) // fiddle with the SpacesBefore field to get canonical spacing
 	return toks
 }
 
@@ -89,7 +89,7 @@ func TokensForTuple(elems []Tokens) Tokens {
 		Bytes: []byte{']'},
 	})
 
-	format(toks) // fiddle with the SpacesBefore field to get canonical spacing
+	toks = format(toks) // fiddle with the SpacesBefore field to get canonical spacing
 	return toks
 }
 
@@ -138,7 +138,7 @@ func TokensForObject(attrs []ObjectAttrTokens) Tokens {
 		Bytes: []byte{'}'},
 	})
 
-	format(toks) // fiddle with the SpacesBefore field to get canonical spacing
+	toks = format(toks) // fiddle with the SpacesBefore field to get canonical spacing
 	return toks
 }
 
@@ -178,7 +178,7 @@ func TokensForFunctionCall(funcName string, args ...Tokens) Tokens {
 		Bytes: []byte{')'},
 	})
 
-	format(toks) // fiddle with the SpacesBefore field to get canonical spacing
+	toks = format(toks) // fiddle with the SpacesBefore field to get canonical spacing
 	return toks
 }
 

--- a/hclwrite/public.go
+++ b/hclwrite/public.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclwrite
@@ -40,7 +40,7 @@ func ParseConfig(src []byte, filename string, start hcl.Pos) (*File, hcl.Diagnos
 // desirable.
 func Format(src []byte) []byte {
 	tokens := lexConfig(src)
-	format(tokens)
+	tokens = format(tokens)
 	buf := &bytes.Buffer{}
 	//nolint:errcheck // FIXME: Propogate errors upward.
 	tokens.WriteTo(buf)


### PR DESCRIPTION
## Description

Appending a nested block into a single-line parent left the child on the same line as `{` (`atlas { cloud { ... } }`). The native parser rejects that: a single-line block definition can contain only a single argument, not a nested block. `hclwrite.Format` did not rewrite this into multi-line form, so generated output could not be parsed again.

`Format` now inserts newlines so a block that contains a nested block is emitted in multi-line form, and the result round-trips.

## Related Issue

Fixes #687

## How Has This Been Tested?

`go test ./hclwrite -count=1 -timeout 60s`, including `TestBodyAppendNewBlockToSingleLineParent` and the format nested-block reparse cases.