### PR TITLE
docs: fix typos in godoc comments

### DIFF
--- a/diagnostic.go
+++ b/diagnostic.go
@@ -173,10 +173,10 @@ type DiagnosticWriter interface {
 //
 // Diagnostic recipients which want to examine "Extra" values to sniff for
 // particular types of extra data can either type-assert this interface
-// directly and repeatedly unwrap until they recieve nil, or can use the
+// directly and repeatedly unwrap until they receive nil, or can use the
 // helper function DiagnosticExtra.
 type DiagnosticExtraUnwrapper interface {
-	// If the reciever is wrapping another "diagnostic extra" value, returns
+	// If the receiver is wrapping another "diagnostic extra" value, returns
 	// that value. Otherwise returns nil to indicate dynamically that nothing
 	// is wrapped.
 	//

--- a/hclsyntax/expression_template.go
+++ b/hclsyntax/expression_template.go
@@ -147,7 +147,7 @@ func (e *TemplateExpr) IsStringLiteral() bool {
 
 // TemplateJoinExpr is used to convert tuples of strings produced by template
 // constructs (i.e. for loops) into flat strings, by converting the values
-// tos strings and joining them. This AST node is not used directly; it's
+// to strings and joining them. This AST node is not used directly; it's
 // produced as part of the AST of a "for" loop in a template.
 type TemplateJoinExpr struct {
 	Tuple Expression

--- a/hclsyntax/public.go
+++ b/hclsyntax/public.go
@@ -16,7 +16,7 @@ import (
 // may freely type-assert this to get access to the full hclsyntax API in
 // situations where detailed access is required. However, most common use-cases
 // should be served using the hcl.Body interface to ensure compatibility with
-// other configurationg syntaxes, such as JSON.
+// other configuration syntaxes, such as JSON.
 func ParseConfig(src []byte, filename string, start hcl.Pos) (*hcl.File, hcl.Diagnostics) {
 	tokens, diags := LexConfig(src, filename, start)
 	peeker := newPeeker(tokens, false)
@@ -92,8 +92,8 @@ func ParseTemplate(src []byte, filename string, start hcl.Pos) (Expression, hcl.
 
 // ParseTraversalAbs parses the given buffer as a standalone absolute traversal.
 //
-// Parsing as a traversal is more limited than parsing as an expession since
-// it allows only attribute and indexing operations on variables. Traverals
+// Parsing as a traversal is more limited than parsing as an expression since
+// it allows only attribute and indexing operations on variables. Traversals
 // are useful as a syntax for referring to objects without necessarily
 // evaluating them.
 func ParseTraversalAbs(src []byte, filename string, start hcl.Pos) (hcl.Traversal, hcl.Diagnostics) {
@@ -101,7 +101,7 @@ func ParseTraversalAbs(src []byte, filename string, start hcl.Pos) (hcl.Traversa
 	peeker := newPeeker(tokens, false)
 	parser := &parser{peeker: peeker}
 
-	// Bare traverals are always parsed in  "ignore newlines" mode, as if
+	// Bare traversals are always parsed in  "ignore newlines" mode, as if
 	// they were wrapped in parentheses.
 	parser.PushIncludeNewlines(false)
 
@@ -132,7 +132,7 @@ func ParseTraversalPartial(src []byte, filename string, start hcl.Pos) (hcl.Trav
 	peeker := newPeeker(tokens, false)
 	parser := &parser{peeker: peeker}
 
-	// Bare traverals are always parsed in  "ignore newlines" mode, as if
+	// Bare traversals are always parsed in  "ignore newlines" mode, as if
 	// they were wrapped in parentheses.
 	parser.PushIncludeNewlines(false)
 

--- a/pos.go
+++ b/pos.go
@@ -72,7 +72,7 @@ func RangeBetween(start, end Range) Range {
 // If either range is empty then it is ignored. The result is empty if both
 // given ranges are empty.
 //
-// The result is meaningless if the two ranges to not belong to the same
+// The result is meaningless if the two ranges do not belong to the same
 // source file.
 func RangeOver(a, b Range) Range {
 	if a.Empty() {
@@ -249,14 +249,14 @@ func (r Range) Overlap(other Range) Range {
 }
 
 // PartitionAround finds the portion of the given range that overlaps with
-// the reciever and returns three ranges: the portion of the reciever that
+// the receiver and returns three ranges: the portion of the receiver that
 // precedes the overlap, the overlap itself, and then the portion of the
-// reciever that comes after the overlap.
+// receiver that comes after the overlap.
 //
 // If the two ranges do not overlap then all three returned ranges are empty.
 //
 // If the given range aligns with or extends beyond either extent of the
-// reciever then the corresponding outer range will be empty.
+// receiver then the corresponding outer range will be empty.
 func (r Range) PartitionAround(other Range) (before, overlap, after Range) {
 	overlap = r.Overlap(other)
 	if overlap.Empty() {


### PR DESCRIPTION
## Description

Fixes 12 typos in godoc comments. Comments only — no code, no identifiers, no exported names, no behaviour changed.

**`pos.go`**
- `the two ranges to not belong` -> `do not belong` (`RangeOver` doc; the sentence three lines above already reads "do not overlap")
- `reciever` -> `receiver`, 4 occurrences in the `PartitionAround` doc comment

**`hclsyntax/public.go`**
- `configurationg` -> `configuration` (`ParseConfig`)
- `expession` -> `expression` and `Traverals` -> `Traversals` (`ParseTraversalAbs`)
- `traverals` -> `traversals`, 2 occurrences (`ParseTraversalAbs`, `ParseTraversalPartial`)

**`hclsyntax/expression_template.go`**
- `converting the values tos strings` -> `to strings` (`TemplateJoinExpr`)

**`diagnostic.go`**
- `until they recieve nil` -> `receive` and `If the reciever is wrapping` -> `receiver` (`DiagnosticExtraUnwrapper`)

`reciever`/`receiver` here is prose about the method receiver, not an identifier. Where the same misspelling appeared more than once inside one doc comment, all occurrences in that comment were corrected so the block reads consistently.

## Related Issue

None.

## How Has This Been Tested?

`go build ./...` and `gofmt -l .` both clean. The change touches only `//` comment text, so no test behaviour is affected.

A wider scan of these files turned up other candidate nits (a stray double space, an incomplete sentence in the `Diagnostic.Extra` doc whose intended wording is not recoverable). Those were deliberately left alone rather than guessed at — this PR is limited to unambiguous misspellings and one wrong word.