### PR TITLE
json: point mismatched delimiter diagnostics at offending token

### DIFF
--- a/json/parser.go
+++ b/json/parser.go
@@ -222,12 +222,12 @@ Token:
 		case tokenBrackC:
 			// Consume the bracket anyway, so that we don't return with the peeker
 			// at a strange place.
-			p.Read()
+			tok := p.Read()
 			return nil, diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Mismatched braces",
 				Detail:   "A JSON object must be closed with a brace, not a bracket.",
-				Subject:  p.Peek().Range.Ptr(),
+				Subject:  &tok.Range,
 			})
 		case tokenBraceC:
 			break Token
@@ -325,12 +325,13 @@ Token:
 				Subject:  &open.Range,
 			})
 		case tokenBraceC:
-			recover(p.Read())
+			tok := p.Read()
+			recover(tok)
 			return nil, diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Mismatched brackets",
 				Detail:   "A JSON array must be closed with a bracket, not a brace.",
-				Subject:  p.Peek().Range.Ptr(),
+				Subject:  &tok.Range,
 			})
 		case tokenBrackC:
 			break Token

--- a/json/parser_test.go
+++ b/json/parser_test.go
@@ -619,6 +619,51 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestMismatchedDelimiterDiagnostics(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		summary string
+		offset  int
+	}{
+		{
+			name:    "array closed with brace",
+			input:   `[1}`,
+			summary: "Mismatched brackets",
+			offset:  2,
+		},
+		{
+			name:    "object closed with bracket",
+			input:   `{"a": 1]`,
+			summary: "Mismatched braces",
+			offset:  7,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, diags := parseFileContent([]byte(test.input), "", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+			if len(diags) != 1 {
+				t.Fatalf("got %d diagnostics; want 1: %s", len(diags), diags.Error())
+			}
+
+			diag := diags[0]
+			if diag.Summary != test.summary {
+				t.Errorf("got summary %q; want %q", diag.Summary, test.summary)
+			}
+			if diag.Subject == nil {
+				t.Fatal("diagnostic has no subject")
+			}
+			if got, want := diag.Subject.Start.Byte, test.offset; got != want {
+				t.Errorf("subject starts at byte %d; want %d", got, want)
+			}
+			if got, want := diag.Subject.End.Byte, test.offset+1; got != want {
+				t.Errorf("subject ends at byte %d; want %d", got, want)
+			}
+		})
+	}
+}
+
 func TestParseWithPos(t *testing.T) {
 	tests := []struct {
 		Input     string


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

<!-- Provide a summary of what the PR does and why it is being submitted. -->

Fix JSON parser diagnostics for mismatched closing delimiters.

When parsing an object closed with `]`, or an array closed with `}`, the parser consumed the offending token and then used `p.Peek()` for the diagnostic subject. This caused the diagnostic range to point at the following token or the recovery position instead of the mismatched delimiter itself.

This change preserves the consumed token and uses its range as the diagnostic subject. Regression tests cover both object and array cases.



## Related Issue

<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

Not applicable.

## How Has This Been Tested?

<!-- Describe how the changes have been tested. Provide test instructions or details. -->

- `go test ./json`
- `go test ./...`
- `go vet ./...`
- `make fmtcheck`