### PR TITLE
hclsyntax: Update copyright year in generated files

### DIFF
--- a/hclsyntax/scan_string_lit.go
+++ b/hclsyntax/scan_string_lit.go
@@ -1,5 +1,5 @@
 //line scan_string_lit.rl:1
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclsyntax

--- a/hclsyntax/scan_tokens.go
+++ b/hclsyntax/scan_tokens.go
@@ -1,5 +1,5 @@
 //line scan_tokens.rl:1
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclsyntax


### PR DESCRIPTION
This is to fix some noise left behind by automation in the past.

TL;DR copywrite initially raised https://github.com/hashicorp/hcl/pull/796 updating copyright years in `hclsyntax/*.rl` files from 2025 to 2026 even though no changes were actually made to these files, so the headers there should not have been updated to begin with.

The Ragel files are used for generating Go code which contains those same headers but updating headers in those files never happened as part of that PR, probably because the tooling ignored generated files. This made the generated code out-of-sync with the source.

Because the automation we continue to use will read git history, the easiest way of addressing this is to "repeat the same mistake" in the generated files. 😓 

## How to review

Run
```
go generate ./...
```

There should no longer be diff in the copyright headers. There might be other diff but I'm addressing that in other PRs.
